### PR TITLE
[FEAT] 특정멤버 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.umc.naoman.domain.member.controller;
+
+
+import com.umc.naoman.domain.member.converter.MemberConverter;
+import com.umc.naoman.domain.member.dto.MemberResponse;
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.service.MemberService;
+import com.umc.naoman.global.result.ResultResponse;
+import com.umc.naoman.global.result.code.MemberResultCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@Slf4j
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/info/{memberId}") // memberId를 사용해 특정 회원 정보 조회
+    public ResultResponse<MemberResponse.MemberInfoByMemberIdDTO> getMemberInfoByMemberId(@PathVariable(name = "memberId") Long memberId) {
+        Member member = memberService.findMember(memberId);
+        return ResultResponse.of(MemberResultCode.MEMBER_INFO,
+                MemberConverter.toMemberInfoByMemberIdDTO(member));
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -22,10 +22,10 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/info/{memberId}") // memberId를 사용해 특정 회원 정보 조회
-    public ResultResponse<MemberResponse.MemberInfoByMemberIdDTO> getMemberInfoByMemberId(@PathVariable(name = "memberId") Long memberId) {
+    @GetMapping("/{memberId}") // memberId를 사용해 특정 회원 정보 조회
+    public ResultResponse<MemberResponse.MemberInfo> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
         Member member = memberService.findMember(memberId);
         return ResultResponse.of(MemberResultCode.MEMBER_INFO,
-                MemberConverter.toMemberInfoByMemberIdDTO(member));
+                MemberConverter.toMemberInfo(member));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
@@ -1,7 +1,17 @@
 package com.umc.naoman.domain.member.converter;
 
+import com.umc.naoman.domain.member.dto.MemberResponse;
+import com.umc.naoman.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberConverter {
+
+    public static MemberResponse.MemberInfoByMemberIdDTO toMemberInfoByMemberIdDTO(Member member) {
+        return MemberResponse.MemberInfoByMemberIdDTO.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .image(member.getImage())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberConverter {
 
-    public static MemberResponse.MemberInfoByMemberIdDTO toMemberInfoByMemberIdDTO(Member member) {
-        return MemberResponse.MemberInfoByMemberIdDTO.builder()
+    public static MemberResponse.MemberInfo toMemberInfo(Member member) {
+        return MemberResponse.MemberInfo.builder()
                 .name(member.getName())
                 .email(member.getEmail())
                 .image(member.getImage())

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
@@ -1,0 +1,4 @@
+package com.umc.naoman.domain.member.dto;
+
+public abstract class MemberRequest {
+}

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
@@ -11,7 +11,7 @@ public abstract class MemberResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemberInfoByMemberIdDTO extends MemberResponse { //특정 회원 조회
+    public static class MemberInfo { //특정 회원 조회
         String name;
         String email;
         String image;

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
@@ -1,0 +1,20 @@
+package com.umc.naoman.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public abstract class MemberResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfoByMemberIdDTO extends MemberResponse { //특정 회원 조회
+        String name;
+        String email;
+        String image;
+    }
+
+}

--- a/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
@@ -13,7 +13,7 @@ public enum MemberResultCode implements ResultCode {
     CHARGE_MY_POINT(200, "SM003","포인트를 성공적으로 충전하였습니다."),
     GET_MY_POINT(200, "SM004", "내 포인트를 성공적으로 조회하였습니다."),
     LOGIN(200, "SM000", "성공적으로 로그인하였습니다."),
-
+    MEMBER_INFO (200,"SM005","회원 정보를 성공적으로 조회하였습니다."),
     ;
     private final int status;
     private final String code;


### PR DESCRIPTION
## ❗️ 이슈 번호
#12 

## 📝 작업 내용
특정회원 정보 조회 api 구현
## 💭 주의 사항
1. 현재 서비스에서는 아직 해당 api를 사용하지 않지만 추후 관리자 페이지 등 기능성 확장을 위해 구현하였습니다.
## 💡 리뷰 포인트
1. memberId를 통한 member 객체 조회 후 해당 member의 정보를 반환하도록 구현했습니다.
2. name, e-mail, 소셜 프로필 이미지 url을 반환합니다.