### PR TITLE
[FEAT] OAuth 방식의 소셜 로그인/회원가입 구현, 스웨거 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,27 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// security
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+	implementation 'commons-io:commons-io:2.6'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/umc/naoman/NaomanApplication.java
+++ b/src/main/java/com/umc/naoman/NaomanApplication.java
@@ -2,7 +2,9 @@ package com.umc.naoman;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class NaomanApplication {
 

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -1,8 +1,9 @@
 package com.umc.naoman.domain.member.controller;
 
-import com.umc.naoman.domain.member.dto.MemberRequest.AndroidLoginRequest;
-import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
-import com.umc.naoman.domain.member.dto.MemberRequest.WebSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.LoginRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.MarketingAgreedRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.service.MemberService;
@@ -32,6 +33,29 @@ import static com.umc.naoman.global.result.code.MemberResultCode.*;
 public class AuthController {
     private final MemberService memberService;
 
+    @PostMapping("/signup/web")
+    @Operation(summary = "회원가입 API(웹)", description = "웹 클라이언트가 사용하는 회원가입 요청 API입니다.")
+    @Parameters(value = {
+            @Parameter(name = "temp-member-info", description = "리다이렉션 시에 쿠키로 넘겨준 사용자 정보가 담긴 jwt를 헤더로 넘겨주세요.",
+                    in = ParameterIn.HEADER)
+    })
+    public ResultResponse<LoginInfo> signup(@RequestHeader("temp-member-info") String tempMemberInfo,
+                                            @Valid @RequestBody MarketingAgreedRequest request) {
+        return ResultResponse.of(SIGNUP, memberService.signup(tempMemberInfo, request));
+    }
+
+    @PostMapping("/signup/android")
+    @Operation(summary = "회원가입 API(안드로이드)", description = "안드로이드 클라이언트가 사용하는 회원가입 API입니다.")
+    public ResultResponse<LoginInfo> signup(@Valid @RequestBody SignupRequest request) {
+        return ResultResponse.of(SIGNUP, memberService.signup(request));
+    }
+
+    @PostMapping("/login/android")
+    @Operation(summary = "로그인 API", description = "안드로이드 클라이언트가 로그인하는 API입니다.")
+    public ResultResponse<LoginInfo> login(@Valid @RequestBody LoginRequest request) {
+        return ResultResponse.of(LOGIN, memberService.login(request));
+    }
+
     @GetMapping("/check-registration")
     @Operation(summary = "회원가입 여부 조회 API", description = "이메일을 통해, 해당 이메일을 가진 회원의 가입 여부를 조회하는 API입니다.")
     @Parameters(value = {
@@ -39,28 +63,5 @@ public class AuthController {
     })
     public ResultResponse<CheckMemberRegistration> checkSignup(@RequestParam("email") @Valid @Email String email) {
         return ResultResponse.of(CHECK_MEMBER_REGISTRATION, memberService.checkRegistration(email));
-    }
-
-    @PostMapping("/signup/android")
-    @Operation(summary = "회원가입 API", description = "안드로이드 클라이언트가 사용하는 회원가입 API입니다.")
-    public ResultResponse<LoginInfo> signup(@Valid @RequestBody AndroidSignupRequest request) {
-        return ResultResponse.of(SIGNUP, memberService.signup(request));
-    }
-
-    @PostMapping("/signup/web")
-    @Operation(summary = "회원가입 요청 API", description = "웹 클라이언트가 사용하는 회원가입 요청 API입니다.")
-    @Parameters(value = {
-            @Parameter(name = "temp-member-info", description = "리다이렉션 시에 쿠키로 넘겨준 사용자 정보가 담긴 jwt를 헤더로 넘겨주세요.",
-                    in = ParameterIn.HEADER)
-    })
-    public ResultResponse<LoginInfo> signup(@RequestHeader("temp-member-info") String tempMemberInfo,
-                                                 @Valid @RequestBody WebSignupRequest request) {
-        return ResultResponse.of(SIGNUP, memberService.signup(tempMemberInfo, request));
-    }
-
-    @PostMapping("/login/android")
-    @Operation(summary = "로그인 API", description = "안드로이드 클라이언트가 로그인하는 API입니다.")
-    public ResultResponse<LoginInfo> login(@Valid @RequestBody AndroidLoginRequest request) {
-        return ResultResponse.of(LOGIN, memberService.login(request));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
 
     @PostMapping("/signup/android")
     @Operation(summary = "회원가입 API", description = "안드로이드 클라이언트가 사용하는 회원가입 API입니다.")
-    public ResultResponse<LoginInfo> checkSignup(@Valid @RequestBody AndroidSignupRequest request) {
+    public ResultResponse<LoginInfo> signup(@Valid @RequestBody AndroidSignupRequest request) {
         return ResultResponse.of(SIGNUP, memberService.signup(request));
     }
 
@@ -53,7 +53,7 @@ public class AuthController {
             @Parameter(name = "temp-member-info", description = "리다이렉션 시에 쿠키로 넘겨준 사용자 정보가 담긴 jwt를 헤더로 넘겨주세요.",
                     in = ParameterIn.HEADER)
     })
-    public ResultResponse<LoginInfo> checkSignup(@RequestHeader("temp-member-info") String tempMemberInfo,
+    public ResultResponse<LoginInfo> signup(@RequestHeader("temp-member-info") String tempMemberInfo,
                                                  @Valid @RequestBody WebSignupRequest request) {
         return ResultResponse.of(SIGNUP, memberService.signup(tempMemberInfo, request));
     }

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.umc.naoman.domain.member.controller;
 
-import com.umc.naoman.domain.member.dto.MemberRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.LoginRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.MarketingAgreedRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -1,11 +1,10 @@
 package com.umc.naoman.domain.member.controller;
 
+import com.umc.naoman.domain.member.dto.MemberRequest.AndroidLoginRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.WebSignupRequest;
-import com.umc.naoman.domain.member.dto.MemberResponse;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
-import com.umc.naoman.domain.member.dto.MemberResponse.MemberId;
 import com.umc.naoman.domain.member.service.MemberService;
 import com.umc.naoman.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,9 +12,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.umc.naoman.global.result.code.MemberResultCode.CHECK_MEMBER_REGISTRATION;
-import static com.umc.naoman.global.result.code.MemberResultCode.SIGNUP;
+import static com.umc.naoman.global.result.code.MemberResultCode.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -43,15 +38,13 @@ public class AuthController {
             @Parameter(name = "email", description = "회원가입 여부를 확인할 이메일을 입력해 주세요.")
     })
     public ResultResponse<CheckMemberRegistration> checkSignup(@RequestParam("email") @Valid @Email String email) {
-        CheckMemberRegistration checkMemberRegistration = memberService.checkRegistration(email);
-        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, checkMemberRegistration);
+        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, memberService.checkRegistration(email));
     }
 
     @PostMapping("/signup/android")
-    @Operation(summary = "회원가입 요청 API", description = "안드로이드 클라이언트가 사용하는 회원가입 요청 API입니다.")
+    @Operation(summary = "회원가입 API", description = "안드로이드 클라이언트가 사용하는 회원가입 API입니다.")
     public ResultResponse<LoginInfo> checkSignup(@Valid @RequestBody AndroidSignupRequest request) {
-        LoginInfo loginInfo = memberService.signup(request);
-        return ResultResponse.of(SIGNUP, loginInfo);
+        return ResultResponse.of(SIGNUP, memberService.signup(request));
     }
 
     @PostMapping("/signup/web")
@@ -62,7 +55,12 @@ public class AuthController {
     })
     public ResultResponse<LoginInfo> checkSignup(@RequestHeader("temp-member-info") String tempMemberInfo,
                                                  @Valid @RequestBody WebSignupRequest request) {
-        LoginInfo loginInfo = memberService.signup(tempMemberInfo, request);
-        return ResultResponse.of(SIGNUP, loginInfo);
+        return ResultResponse.of(SIGNUP, memberService.signup(tempMemberInfo, request));
+    }
+
+    @PostMapping("/login/android")
+    @Operation(summary = "로그인 API", description = "안드로이드 클라이언트가 로그인하는 API입니다.")
+    public ResultResponse<LoginInfo> login(@Valid @RequestBody AndroidLoginRequest request) {
+        return ResultResponse.of(LOGIN, memberService.login(request));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -1,0 +1,68 @@
+package com.umc.naoman.domain.member.controller;
+
+import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.WebSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberResponse;
+import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
+import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
+import com.umc.naoman.domain.member.dto.MemberResponse.MemberId;
+import com.umc.naoman.domain.member.service.MemberService;
+import com.umc.naoman.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.umc.naoman.global.result.code.MemberResultCode.CHECK_MEMBER_REGISTRATION;
+import static com.umc.naoman.global.result.code.MemberResultCode.SIGNUP;
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "인증,인가 관련 API", description = "회원의 회원가입 및 로그인 등을 처리하는 API입니다.")
+@RequiredArgsConstructor
+public class AuthController {
+    private final MemberService memberService;
+
+    @GetMapping("/check-registration")
+    @Operation(summary = "회원가입 여부 조회 API", description = "이메일을 통해, 해당 이메일을 가진 회원의 가입 여부를 조회하는 API입니다.")
+    @Parameters(value = {
+            @Parameter(name = "email", description = "회원가입 여부를 확인할 이메일을 입력해 주세요.")
+    })
+    public ResultResponse<CheckMemberRegistration> checkSignup(@RequestParam("email") @Valid @Email String email) {
+        CheckMemberRegistration checkMemberRegistration = memberService.checkRegistration(email);
+        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, checkMemberRegistration);
+    }
+
+    @PostMapping("/signup/android")
+    @Operation(summary = "회원가입 요청 API", description = "안드로이드 클라이언트가 사용하는 회원가입 요청 API입니다.")
+    public ResultResponse<LoginInfo> checkSignup(@Valid @RequestBody AndroidSignupRequest request) {
+        LoginInfo loginInfo = memberService.signup(request);
+        return ResultResponse.of(SIGNUP, loginInfo);
+    }
+
+    @PostMapping("/signup/web")
+    @Operation(summary = "회원가입 요청 API", description = "웹 클라이언트가 사용하는 회원가입 요청 API입니다.")
+    @Parameters(value = {
+            @Parameter(name = "temp-member-info", description = "리다이렉션 시에 쿠키로 넘겨준 사용자 정보가 담긴 jwt를 헤더로 넘겨주세요.",
+                    in = ParameterIn.HEADER)
+    })
+    public ResultResponse<LoginInfo> checkSignup(@RequestHeader("temp-member-info") String tempMemberInfo,
+                                                 @Valid @RequestBody WebSignupRequest request) {
+        LoginInfo loginInfo = memberService.signup(tempMemberInfo, request);
+        return ResultResponse.of(SIGNUP, loginInfo);
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -1,6 +1,9 @@
 package com.umc.naoman.domain.member.controller;
 
+import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.service.MemberService;
+import com.umc.naoman.global.result.ResultResponse;
+import com.umc.naoman.global.security.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.umc.naoman.domain.member.controller;
 
-import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.service.MemberService;
-import com.umc.naoman.global.result.ResultResponse;
-import com.umc.naoman.global.security.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -1,0 +1,15 @@
+package com.umc.naoman.domain.member.controller;
+
+import com.umc.naoman.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@Tag(name = "회원 API", description = "회원 도메인의 API입니다.")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+}

--- a/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
@@ -1,18 +1,21 @@
 package com.umc.naoman.domain.member.converter;
 
-import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.entity.SocialType;
+import io.jsonwebtoken.Claims;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberConverter {
-    public Member toEntity(AndroidSignupRequest request) {
+    public Member toEntity(SignupRequest request) {
         return Member.builder()
                 .email(request.getEmail())
                 .name(request.getName())
                 .image(request.getImage())
                 .socialType(request.getSocialType())
+                .authId(request.getAuthId())
                 .marketingAgreed(request.getMarketingAgreed())
                 .build();
     }
@@ -22,6 +25,17 @@ public class MemberConverter {
                 .memberId(memberId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .build();
+    }
+
+    public SignupRequest toSignupRequest(Claims payload, boolean marketingAgreed) {
+        return SignupRequest.builder()
+                .email(payload.get("email", String.class))
+                .name(payload.get("name", String.class))
+                .image(payload.get("image", String.class))
+                .socialType(SocialType.valueOf(payload.get("socialType", String.class)))
+                .authId(payload.get("authId", String.class))
+                .marketingAgreed(marketingAgreed)
                 .build();
     }
 

--- a/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
@@ -1,7 +1,28 @@
 package com.umc.naoman.domain.member.converter;
 
+import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
+import com.umc.naoman.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberConverter {
+    public Member toEntity(AndroidSignupRequest request) {
+        return Member.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .image(request.getImage())
+                .socialType(request.getSocialType())
+                .marketingAgreed(request.getMarketingAgreed())
+                .build();
+    }
+
+    public LoginInfo toLoginInfo(Long memberId, String accessToken, String refreshToken) {
+        return LoginInfo.builder()
+                .memberId(memberId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
 }

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
@@ -1,0 +1,36 @@
+package com.umc.naoman.domain.member.dto;
+
+import com.umc.naoman.domain.member.entity.SocialType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+public abstract class MemberRequest {
+    @Getter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WebSignupRequest {
+        @NotNull
+        private Boolean marketingAgreed;
+    }
+
+    @Getter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AndroidSignupRequest extends WebSignupRequest {
+        @Email(message = "이메일의 경우, 올바른 이메일 형식으로 입력해야 합니다.")
+        @NotBlank
+        private String email;
+        @NotBlank(message = "이름은 공백 또는 빈 문자열일 수 없습니다.")
+        private String name;
+        private String image;
+        @NotNull
+        private SocialType socialType;
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
@@ -3,30 +3,26 @@ package com.umc.naoman.domain.member.dto;
 import com.umc.naoman.domain.member.entity.SocialType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 public abstract class MemberRequest {
     @Getter
-    @SuperBuilder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class WebSignupRequest {
-        // 별도의 데이터는 쿠키로 들어온다.
+    public static class MarketingAgreedRequest {
         @NotNull
         private Boolean marketingAgreed;
     }
 
     @Getter
-    @SuperBuilder
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class AndroidSignupRequest extends WebSignupRequest {
+    public static class SignupRequest {
         @Email(message = "이메일의 경우, 올바른 이메일 형식으로 입력해야 합니다.")
         @NotBlank
         private String email;
@@ -35,18 +31,20 @@ public abstract class MemberRequest {
         private String image;
         @NotNull(message = "socialType은 KAKAO, GOOGLE 중 하나를 입력해야 합니다.")
         private SocialType socialType;
-        @NotNull(message = "authId는 소셜 플랫폼에서 제공한 회원 번호를 필수로 입력해야 합니다.")
-        private Long authId;
+        @NotBlank(message = "authId는 소셜 플랫폼에서 제공한 회원 번호를 필수로 입력해야 합니다.")
+        private String authId;
+        @NotNull(message = "마케팅 약관 동의 여부는 필수로 입력해야 합니다.")
+        private Boolean marketingAgreed;
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class AndroidLoginRequest {
-        @NotNull(message = "로그인한 소셜 플랫폼의 회원 id를 입력해야 합니다.")
-        private Long authId;
-        @NotNull
+    public static class LoginRequest {
+        @NotNull(message = "로그인한 소셜 플랫폼에서 제공한 회원 번호를 필수로 입력해야 합니다.")
+        private String authId;
+        @NotNull(message = "socialType은 KAKAO, GOOGLE 중 하나를 입력해야 합니다.")
         private SocialType socialType;
 
     }

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
@@ -3,6 +3,7 @@ package com.umc.naoman.domain.member.dto;
 import com.umc.naoman.domain.member.entity.SocialType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public abstract class MemberRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class WebSignupRequest {
+        // 별도의 데이터는 쿠키로 들어온다.
         @NotNull
         private Boolean marketingAgreed;
     }
@@ -31,8 +33,10 @@ public abstract class MemberRequest {
         @NotBlank(message = "이름은 공백 또는 빈 문자열일 수 없습니다.")
         private String name;
         private String image;
-        @NotNull
+        @NotNull(message = "socialType은 KAKAO, GOOGLE 중 하나를 입력해야 합니다.")
         private SocialType socialType;
+        @NotNull(message = "authId는 소셜 플랫폼에서 제공한 회원 번호를 필수로 입력해야 합니다.")
+        private Long authId;
     }
 
     @Getter

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -32,5 +33,17 @@ public abstract class MemberRequest {
         private String image;
         @NotNull
         private SocialType socialType;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AndroidLoginRequest {
+        @NotNull(message = "로그인한 소셜 플랫폼의 회원 id를 입력해야 합니다.")
+        private Long authId;
+        @NotNull
+        private SocialType socialType;
+
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
@@ -1,0 +1,28 @@
+package com.umc.naoman.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public abstract class MemberResponse {
+    @Getter
+    @AllArgsConstructor
+    public static class CheckMemberRegistration {
+        private Boolean isRegistered;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MemberId {
+        private Long memberId;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LoginInfo {
+        private Long memberId;
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/Member.java
@@ -33,6 +33,8 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
     private String image;
+    @Column(name = "auth_id", nullable = false)
+    private Long authId;
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type", nullable = false)
     private SocialType socialType;

--- a/src/main/java/com/umc/naoman/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/Member.java
@@ -34,7 +34,7 @@ public class Member extends BaseTimeEntity {
     private String name;
     private String image;
     @Column(name = "auth_id", nullable = false)
-    private Long authId;
+    private String authId;
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type", nullable = false)
     private SocialType socialType;

--- a/src/main/java/com/umc/naoman/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/Member.java
@@ -38,4 +38,10 @@ public class Member extends BaseTimeEntity {
     private SocialType socialType;
     @Column(name = "marketing_agreed")
     private boolean marketingAgreed;
+
+    public Member update(String name, String image) {
+        this.name = name;
+        this.image = image;
+        return this;
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/member/entity/SocialType.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/SocialType.java
@@ -1,7 +1,12 @@
 package com.umc.naoman.domain.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.umc.naoman.global.error.BusinessException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import static com.umc.naoman.global.error.code.MemberErrorCode.INVALID_SOCIAL_TYPE;
 
 @Getter
 @RequiredArgsConstructor
@@ -10,4 +15,13 @@ public enum SocialType {
     GOOGLE("sub");
 
     private final String usernameAttributeKey;
+
+    @JsonCreator
+    public static SocialType fromString(String value) {
+        try {
+            return SocialType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(INVALID_SOCIAL_TYPE);
+        }
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/member/entity/SocialType.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/SocialType.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.umc.naoman.global.error.BusinessException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import static com.umc.naoman.global.error.code.MemberErrorCode.INVALID_SOCIAL_TYPE;
 

--- a/src/main/java/com/umc/naoman/domain/member/entity/redis/RefreshToken.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/redis/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.umc.naoman.domain.member.entity.redis;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.io.Serializable;
+
+@Getter
+@RedisHash(value = "refreshToken")
+public class RefreshToken implements Serializable {
+    @Id
+    @Indexed
+    private String refreshToken;
+    @Indexed
+    private Long memberId;
+    @TimeToLive
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private Long expiration;
+
+    public RefreshToken(final Long memberId, final String refreshToken) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+    }
+
+    public RefreshToken update(String refreshToken) {
+        this.refreshToken = refreshToken;
+        return this;
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/naoman/domain/member/repository/MemberRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
-    Optional<Member> findByAuthIdAndSocialType(Long authId, SocialType socialType);
+    Optional<Member> findByAuthIdAndSocialType(String authId, SocialType socialType);
     Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/umc/naoman/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/naoman/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.umc.naoman.domain.member.repository;
 
 import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.entity.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByAuthIdAndSocialType(Long authId, SocialType socialType);
     Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/umc/naoman/domain/member/repository/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/umc/naoman/domain/member/repository/redis/RefreshTokenRepository.java
@@ -1,13 +1,13 @@
 package com.umc.naoman.domain.member.repository.redis;
 
 import com.umc.naoman.domain.member.entity.redis.RefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByMemberId(Long memberId);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/umc/naoman/domain/member/repository/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/umc/naoman/domain/member/repository/redis/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.umc.naoman.domain.member.repository.redis;
+
+import com.umc.naoman.domain.member.entity.redis.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByMemberId(Long memberId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
@@ -1,8 +1,8 @@
 package com.umc.naoman.domain.member.service;
 
-import com.umc.naoman.domain.member.dto.MemberRequest.AndroidLoginRequest;
-import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
-import com.umc.naoman.domain.member.dto.MemberRequest.WebSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.LoginRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.MarketingAgreedRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.entity.Member;
@@ -11,10 +11,10 @@ import com.umc.naoman.domain.member.entity.SocialType;
 public interface MemberService {
     Member findMember(Long memberId);
     Member findMember(String email);
-    Member findMember(Long authId, SocialType socialType);
+    Member findMember(String authId, SocialType socialType);
     CheckMemberRegistration checkRegistration(String email);
-    LoginInfo signup(AndroidSignupRequest request);
-    LoginInfo signup(String tempMemberInfo, WebSignupRequest request);
-    LoginInfo login(AndroidLoginRequest request);
+    LoginInfo signup(SignupRequest request);
+    LoginInfo signup(String tempMemberInfo, MarketingAgreedRequest request);
+    LoginInfo login(LoginRequest request);
     // MyPageInfo getMyPageInfo(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
@@ -1,16 +1,20 @@
 package com.umc.naoman.domain.member.service;
 
+import com.umc.naoman.domain.member.dto.MemberRequest.AndroidLoginRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.WebSignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.entity.SocialType;
 
 public interface MemberService {
     Member findMember(Long memberId);
     Member findMember(String email);
+    Member findMember(Long authId, SocialType socialType);
     CheckMemberRegistration checkRegistration(String email);
     LoginInfo signup(AndroidSignupRequest request);
     LoginInfo signup(String tempMemberInfo, WebSignupRequest request);
+    LoginInfo login(AndroidLoginRequest request);
     // MyPageInfo getMyPageInfo(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
@@ -1,10 +1,16 @@
 package com.umc.naoman.domain.member.service;
 
+import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.WebSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
+import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.entity.Member;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
     Member findMember(Long memberId);
     Member findMember(String email);
+    CheckMemberRegistration checkRegistration(String email);
+    LoginInfo signup(AndroidSignupRequest request);
+    LoginInfo signup(String tempMemberInfo, WebSignupRequest request);
     // MyPageInfo getMyPageInfo(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
@@ -85,6 +85,7 @@ public class MemberServiceImpl implements MemberService {
                 .name(payload.get("name", String.class))
                 .image(payload.get("image", String.class))
                 .socialType(SocialType.valueOf(payload.get("socialType", String.class)))
+                .authId(payload.get("authId", Long.class))
                 .marketingAgreed(request.getMarketingAgreed())
                 .build();
 

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
@@ -1,28 +1,86 @@
 package com.umc.naoman.domain.member.service;
 
+import com.umc.naoman.domain.member.converter.MemberConverter;
+import com.umc.naoman.domain.member.dto.MemberRequest.AndroidSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberRequest.WebSignupRequest;
+import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
+import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.entity.SocialType;
 import com.umc.naoman.domain.member.repository.MemberRepository;
+import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
 import com.umc.naoman.global.error.BusinessException;
-import com.umc.naoman.global.error.code.MemberErrorCode;
+import com.umc.naoman.global.security.util.JwtUtils;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.umc.naoman.global.error.code.MemberErrorCode.*;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
+    private final RefreshTokenService refreshTokenService;
     private final MemberRepository memberRepository;
+    private final MemberConverter memberConverter;
+    private final JwtUtils jwtUtils;
+    @Value("${jwt.access-token-validity-in-seconds}")
+    private Long ACCESS_TOKEN_VALIDITY_IN_SECONDS;
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private Long REFRESH_TOKEN_VALIDITY_IN_SECONDS;
 
     @Override
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND_BY_MEMBER_ID));
+                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_BY_MEMBER_ID));
     }
 
     @Override
     public Member findMember(String email) {
         return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND_BY_EMAIL));
+                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_BY_EMAIL));
+    }
+
+    @Override
+    public CheckMemberRegistration checkRegistration(String email) {
+        boolean isRegistered = memberRepository.existsByEmail(email);
+        return new CheckMemberRegistration(isRegistered);
+    }
+
+    @Override
+    @Transactional
+    public LoginInfo signup(AndroidSignupRequest request) {
+        if (memberRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(MEMBER_ALREADY_SIGNUP);
+        }
+
+        Member member = memberConverter.toEntity(request);
+        memberRepository.save(member);
+
+        // 회원가입 완료 후 로그인 처리를 위해 access token, refresh token 발급
+        // 별도 권한 정책이 없으므로 default 처리
+        String role = "ROLE_DEFAULT";
+        String accessToken = jwtUtils.createJwt(member.getEmail(), role, ACCESS_TOKEN_VALIDITY_IN_SECONDS);
+        String refreshToken = jwtUtils.createJwt(member.getEmail(), role, REFRESH_TOKEN_VALIDITY_IN_SECONDS);
+        refreshTokenService.saveRefreshToken(member.getId(), refreshToken);
+        return memberConverter.toLoginInfo(member.getId(), accessToken, refreshToken);
+    }
+
+    @Override
+    @Transactional
+    public LoginInfo signup(String tempMemberInfo, WebSignupRequest request) {
+        Claims payload = jwtUtils.getPayload(tempMemberInfo);
+        AndroidSignupRequest androidSignupRequest = AndroidSignupRequest.builder()
+                .email(payload.get("email", String.class))
+                .name(payload.get("name", String.class))
+                .image(payload.get("image", String.class))
+                .socialType(SocialType.valueOf(payload.get("socialType", String.class)))
+                .marketingAgreed(request.getMarketingAgreed())
+                .build();
+
+        return signup(androidSignupRequest);
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/redis/RefreshTokenService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/redis/RefreshTokenService.java
@@ -1,0 +1,8 @@
+package com.umc.naoman.domain.member.service.redis;
+
+import com.umc.naoman.domain.member.entity.redis.RefreshToken;
+
+public interface RefreshTokenService {
+    RefreshToken findByRefreshToken(String refreshToken);
+    void saveRefreshToken(Long memberId, String refreshToken);
+}

--- a/src/main/java/com/umc/naoman/domain/member/service/redis/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/redis/RefreshTokenServiceImpl.java
@@ -1,0 +1,32 @@
+package com.umc.naoman.domain.member.service.redis;
+
+import com.umc.naoman.domain.member.entity.redis.RefreshToken;
+import com.umc.naoman.domain.member.repository.redis.RefreshTokenRepository;
+import com.umc.naoman.global.error.BusinessException;
+import com.umc.naoman.global.error.code.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public RefreshToken findByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.REFRESH_TOKEN_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public void saveRefreshToken(Long memberId, String refreshToken) {
+        RefreshToken updatedRefreshToken = refreshTokenRepository.findByMemberId(memberId)
+                .map(originalRefreshToken -> originalRefreshToken.update(refreshToken))
+                .orElse(new RefreshToken(memberId, refreshToken));
+
+        refreshTokenRepository.save(updatedRefreshToken);
+    }
+}

--- a/src/main/java/com/umc/naoman/global/config/SwaggerConfig.java
+++ b/src/main/java/com/umc/naoman/global/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.umc.naoman.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+//        Server server = new Server();
+//        server.setUrl("http://{EC2_인스턴스의_IPv4_주소}");
+
+        Server local = new Server();
+        local.setUrl("http://localhost:8080");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(Arrays.asList(securityRequirement))
+                .info(apiInfo()).servers(List.of(local));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("턴페이지 서비스 API")
+                .description("독후감 작성, 조회와 중고 도서 판매 등의 기능을 제공합니다.")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
@@ -10,6 +10,8 @@ public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND_BY_MEMBER_ID(404, "EM001", "해당 memberId를 가진 회원이 존재하지 않습니다."),
     MEMBER_NOT_FOUND_BY_EMAIL(404, "EM002", "해당 이메일을 가진 회원이 존재하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(404, "EM000", "해당 refresh token이 존재하지 않습니다."),
+    INVALID_SOCIAL_TYPE(404, "EM000", "해당 socialType은 유효하지 않습니다."),
+    MEMBER_ALREADY_SIGNUP(400, "EM000", "해당 이메일을 가진 회원은 이미 회원가입하였습니다."),
 
     ;
 

--- a/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND_BY_MEMBER_ID(404, "EM001", "해당 memberId를 가진 회원이 존재하지 않습니다."),
     MEMBER_NOT_FOUND_BY_EMAIL(404, "EM002", "해당 이메일을 가진 회원이 존재하지 않습니다."),
+    MEMBER_NOT_FOUND_BY_AUTH_ID_AND_SOCIAL_TYPE(404, "EM003", "해당 authId와 socialType을 가진 회원이 존재하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(404, "EM000", "해당 refresh token이 존재하지 않습니다."),
     INVALID_SOCIAL_TYPE(404, "EM000", "해당 socialType은 유효하지 않습니다."),
     MEMBER_ALREADY_SIGNUP(400, "EM000", "해당 이메일을 가진 회원은 이미 회원가입하였습니다."),

--- a/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND_BY_MEMBER_ID(404, "EM001", "해당 memberId를 가진 회원이 존재하지 않습니다."),
     MEMBER_NOT_FOUND_BY_EMAIL(404, "EM002", "해당 이메일을 가진 회원이 존재하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(404, "EM000", "해당 refresh token이 존재하지 않습니다."),
+
     ;
 
     private final int status;

--- a/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
@@ -8,11 +8,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberResultCode implements ResultCode {
+    SIGNUP(200, "SM000", "성공적으로 회원가입하였습니다."),
+    LOGIN(200, "SM000", "성공적으로 로그인하였습니다."),
     MYPAGE_INFO(200, "SM001", "내 정보를 성공적으로 조회하였습니다."),
     EDIT_MYPAGE_INFO(200, "SM002", "내 정보를 성공적으로 수정하였습니다."),
-    CHARGE_MY_POINT(200, "SM003","포인트를 성공적으로 충전하였습니다."),
-    GET_MY_POINT(200, "SM004", "내 포인트를 성공적으로 조회하였습니다."),
-    LOGIN(200, "SM000", "성공적으로 로그인하였습니다."),
+    CHECK_MEMBER_REGISTRATION(200, "SM000", "해당 이메일을 가진 회원의 가입 여부를 성공적으로 조회하였습니다."),
 
     ;
     private final int status;

--- a/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
@@ -1,6 +1,5 @@
 package com.umc.naoman.global.result.code;
 
-
 import com.umc.naoman.global.result.ResultCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
@@ -1,0 +1,91 @@
+package com.umc.naoman.global.security;
+
+import com.umc.naoman.domain.member.repository.MemberRepository;
+import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
+import com.umc.naoman.global.security.filter.JwtAuthenticationFilter;
+import com.umc.naoman.global.security.handler.CustomAccessDeniedHandler;
+import com.umc.naoman.global.security.handler.OAuth2LoginSuccessHandler;
+import com.umc.naoman.global.security.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.umc.naoman.global.security.service.CustomOAuth2UserService;
+import com.umc.naoman.global.security.util.JwtUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtils jwtUtils;
+    private final MemberRepository memberRepository;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final RefreshTokenService refreshTokenService;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Bean
+    public OAuth2AuthorizationRequestBasedOnCookieRepository oAuth2AuthorizationRequestBasedOnCookieRepository() {
+        return new OAuth2AuthorizationRequestBasedOnCookieRepository();
+    }
+
+    @Bean
+    public OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler() {
+        return new OAuth2LoginSuccessHandler(jwtUtils, refreshTokenService,
+                memberRepository, oAuth2AuthorizationRequestBasedOnCookieRepository());
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder amBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        AuthenticationManager authenticationManager = amBuilder.build();
+
+        http.authenticationManager(authenticationManager);
+
+        http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                        .disable()
+                )
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/images/**").permitAll()
+                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/callback/oauth2/code/**").permitAll()
+                        .requestMatchers("/error/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/members/new").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-resources/**",
+                                "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(exception -> exception.accessDeniedHandler(customAccessDeniedHandler))
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository()))
+                        .userInfoEndpoint(userInfoEndpointConfig ->
+                                userInfoEndpointConfig.userService(customOAuth2UserService))
+                        .successHandler(oAuth2LoginSuccessHandler())
+                        .loginPage("/auth/login")
+                )
+                .addFilterAfter(new JwtAuthenticationFilter(jwtUtils), OAuth2LoginAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.umc.naoman.global.security;
 
-import com.umc.naoman.domain.member.repository.MemberRepository;
 import com.umc.naoman.domain.member.service.MemberService;
 import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
 import com.umc.naoman.global.security.filter.JwtAuthenticationFilter;

--- a/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.umc.naoman.global.security;
 
 import com.umc.naoman.domain.member.repository.MemberRepository;
+import com.umc.naoman.domain.member.service.MemberService;
 import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
 import com.umc.naoman.global.security.filter.JwtAuthenticationFilter;
 import com.umc.naoman.global.security.handler.CustomAccessDeniedHandler;
@@ -11,18 +12,10 @@ import com.umc.naoman.global.security.util.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
-import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -30,12 +23,11 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final AuthenticationConfiguration authenticationConfiguration;
-    private final JwtUtils jwtUtils;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final RefreshTokenService refreshTokenService;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final JwtUtils jwtUtils;
 
     @Bean
     public OAuth2AuthorizationRequestBasedOnCookieRepository oAuth2AuthorizationRequestBasedOnCookieRepository() {
@@ -44,17 +36,12 @@ public class SecurityConfig {
 
     @Bean
     public OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler() {
-        return new OAuth2LoginSuccessHandler(jwtUtils, refreshTokenService,
-                memberRepository, oAuth2AuthorizationRequestBasedOnCookieRepository());
+        return new OAuth2LoginSuccessHandler(jwtUtils, refreshTokenService, memberService,
+                oAuth2AuthorizationRequestBasedOnCookieRepository());
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        AuthenticationManagerBuilder amBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
-        AuthenticationManager authenticationManager = amBuilder.build();
-
-        http.authenticationManager(authenticationManager);
-
         http
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
@@ -64,11 +51,8 @@ public class SecurityConfig {
                         .disable()
                 )
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/images/**").permitAll()
                         .requestMatchers("/auth/**").permitAll()
-                        .requestMatchers("/callback/oauth2/code/**").permitAll()
                         .requestMatchers("/error/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/members/new").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/swagger-resources/**",

--- a/src/main/java/com/umc/naoman/global/security/annotation/LoginMember.java
+++ b/src/main/java/com/umc/naoman/global/security/annotation/LoginMember.java
@@ -1,0 +1,14 @@
+package com.umc.naoman.global.security.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : member")
+public @interface LoginMember {
+}

--- a/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
+++ b/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
@@ -14,7 +14,7 @@ public class OAuthAttribute {
     private final String name;
     private final String image;
     private final SocialType provider;
-    private final Long authId;
+    private final String authId;
     private final String usernameAttributeKey;
     private final Map<String, Object> attributes;
 
@@ -30,7 +30,7 @@ public class OAuthAttribute {
 
     private static OAuthAttribute ofKakao(Map<String, Object> attributes) {
         // 카카오의 경우 사용자 정보 데이터의 형태가 이중 Map이므로, 이를 풀어서 사용한다.
-        Long authId = (Long) attributes.get("id");
+        String authId = String.valueOf(attributes.get(SocialType.KAKAO.getUsernameAttributeKey()));
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
@@ -51,7 +51,7 @@ public class OAuthAttribute {
                 .name(String.valueOf(attributes.get("name")))
                 .image(String.valueOf(attributes.get("picture")))
                 .provider(SocialType.GOOGLE)
-                .authId((Long) attributes.get("id"))
+                .authId(String.valueOf(attributes.get(SocialType.GOOGLE.getUsernameAttributeKey())))
                 .usernameAttributeKey(SocialType.GOOGLE.getUsernameAttributeKey())
                 .attributes(attributes)
                 .build();

--- a/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
+++ b/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
@@ -4,7 +4,6 @@ import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.entity.SocialType;
 import lombok.Builder;
 import lombok.Getter;
-import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.Map;
 

--- a/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
+++ b/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
@@ -14,6 +14,7 @@ public class OAuthAttribute {
     private final String name;
     private final String image;
     private final SocialType provider;
+    private final Long authId;
     private final String usernameAttributeKey;
     private final Map<String, Object> attributes;
 
@@ -29,6 +30,7 @@ public class OAuthAttribute {
 
     private static OAuthAttribute ofKakao(Map<String, Object> attributes) {
         // 카카오의 경우 사용자 정보 데이터의 형태가 이중 Map이므로, 이를 풀어서 사용한다.
+        Long authId = (Long) attributes.get("id");
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
@@ -37,6 +39,7 @@ public class OAuthAttribute {
                 .name(String.valueOf(profile.get("nickname")))
                 .image(String.valueOf(profile.get("profile_image_url")))
                 .provider(SocialType.KAKAO)
+                .authId(authId)
                 .usernameAttributeKey(SocialType.KAKAO.getUsernameAttributeKey())
                 .attributes(attributes)
                 .build();
@@ -48,6 +51,7 @@ public class OAuthAttribute {
                 .name(String.valueOf(attributes.get("name")))
                 .image(String.valueOf(attributes.get("picture")))
                 .provider(SocialType.GOOGLE)
+                .authId((Long) attributes.get("id"))
                 .usernameAttributeKey(SocialType.GOOGLE.getUsernameAttributeKey())
                 .attributes(attributes)
                 .build();
@@ -59,6 +63,7 @@ public class OAuthAttribute {
                 .name(name)
                 .image(image)
                 .socialType(provider)
+                .authId(authId)
                 .build();
     }
 

--- a/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
+++ b/src/main/java/com/umc/naoman/global/security/attribute/OAuthAttribute.java
@@ -1,0 +1,69 @@
+package com.umc.naoman.global.security.attribute;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.entity.SocialType;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class OAuthAttribute {
+    private final String email;
+    private final String name;
+    private final String image;
+    private final SocialType provider;
+    private final String usernameAttributeKey;
+    private final Map<String, Object> attributes;
+
+    public static OAuthAttribute of(String provider, Map<String, Object> attributes) {
+        if (isEqualProvider(provider, SocialType.KAKAO)) {
+            return ofKakao(attributes);
+        } else if (isEqualProvider(provider, SocialType.GOOGLE)) {
+            return ofGoogle(attributes);
+        }
+
+        return null;
+    }
+
+    private static OAuthAttribute ofKakao(Map<String, Object> attributes) {
+        // 카카오의 경우 사용자 정보 데이터의 형태가 이중 Map이므로, 이를 풀어서 사용한다.
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        return OAuthAttribute.builder()
+                .email(String.valueOf(kakaoAccount.get("email")))
+                .name(String.valueOf(profile.get("nickname")))
+                .image(String.valueOf(profile.get("profile_image_url")))
+                .provider(SocialType.KAKAO)
+                .usernameAttributeKey(SocialType.KAKAO.getUsernameAttributeKey())
+                .attributes(attributes)
+                .build();
+    }
+
+    private static OAuthAttribute ofGoogle(Map<String, Object> attributes) {
+        return OAuthAttribute.builder()
+                .email(String.valueOf(attributes.get("email")))
+                .name(String.valueOf(attributes.get("name")))
+                .image(String.valueOf(attributes.get("picture")))
+                .provider(SocialType.GOOGLE)
+                .usernameAttributeKey(SocialType.GOOGLE.getUsernameAttributeKey())
+                .attributes(attributes)
+                .build();
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .email(email)
+                .name(name)
+                .image(image)
+                .socialType(provider)
+                .build();
+    }
+
+    private static boolean isEqualProvider(String provider, SocialType socialType) {
+        return provider.toUpperCase().equals(socialType.toString());
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/naoman/global/security/filter/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String AUTHORIZATION_TYPE = "Bearer ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
     private final JwtUtils jwtUtils;
     public JwtAuthenticationFilter(JwtUtils jwtUtils) {
         this.jwtUtils = jwtUtils;
@@ -21,7 +22,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String authorization = request.getHeader("Authorization");
+        String authorization = request.getHeader(AUTHORIZATION_HEADER);
 
         if (!validateJwtIsPresent(authorization)) {
             filterChain.doFilter(request, response);
@@ -43,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private boolean validateJwtIsPresent(String authorization) {
         if (authorization == null || !authorization.startsWith(AUTHORIZATION_TYPE)) {
-            System.out.println("토큰이 존재하지 않거나, 인증 타입이 Bearer가 아닙니다.");
+//            System.out.println("토큰이 존재하지 않거나, 인증 타입이 Bearer가 아닙니다.");
             return false;
         }
 

--- a/src/main/java/com/umc/naoman/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/naoman/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.umc.naoman.global.security.filter;
+
+import com.umc.naoman.global.security.util.JwtUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String AUTHORIZATION_TYPE = "Bearer ";
+    private final JwtUtils jwtUtils;
+    public JwtAuthenticationFilter(JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
+
+        if (!validateJwtIsPresent(authorization)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String jwt = authorization.substring(AUTHORIZATION_TYPE.length());
+        System.out.println("jwt: " + jwt);
+        if (jwtUtils.isExpired(jwt)) {
+            System.out.println("토큰이 만료되었습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = jwtUtils.getAuthentication(jwt);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean validateJwtIsPresent(String authorization) {
+        if (authorization == null || !authorization.startsWith(AUTHORIZATION_TYPE)) {
+            System.out.println("토큰이 존재하지 않거나, 인증 타입이 Bearer가 아닙니다.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.umc.naoman.global.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        if (accessDeniedException != null) {
+            request.getRequestDispatcher("/access/denied").forward(request, response);
+        }
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -38,8 +38,10 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     @Value("${jwt.temp-member-info-validity-in-seconds}")
     private Long TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS;
     private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String REFRESH_TOKEN_KEY = "refresh_token";
-    private static final String TEMP_MEMBER_INFO_KEY = "temp_member_info";
+    private static final String REFRESH_TOKEN_KEY = "refresh-token";
+    private static final String TEMP_MEMBER_INFO_KEY = "temp-member-info";
+    private static final String FRONTEND_BASE_URL = "http://localhost:3000";
+    private static final String FRONTEND_AGREEMENT_PATH = "/enter/login/clause";
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -77,7 +79,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         clearAuthenticationAttributes(request, response);
         // 프론트엔드 홈 화면으로 리다이렉션
-        response.sendRedirect("http://localhost:3000");
+        response.sendRedirect(FRONTEND_BASE_URL);
     }
 
     private void handleMemberSignup(HttpServletRequest request, HttpServletResponse response, OAuthAttribute oAuthAttribute)
@@ -88,7 +90,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         clearAuthenticationAttributes(request, response);
         // 약관 동의 화면으로 리다이렉션
-        response.sendRedirect("http://localhost:3000/terms");
+        response.sendRedirect(FRONTEND_BASE_URL + FRONTEND_AGREEMENT_PATH);
     }
 
     private void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {

--- a/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -1,62 +1,90 @@
 package com.umc.naoman.global.security.handler;
 
 import com.umc.naoman.domain.member.entity.Member;
-import com.umc.naoman.domain.member.repository.MemberRepository;
+import com.umc.naoman.domain.member.service.MemberService;
 import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
+import com.umc.naoman.global.error.BusinessException;
+import com.umc.naoman.global.security.attribute.OAuthAttribute;
 import com.umc.naoman.global.security.model.CustomOAuth2User;
 import com.umc.naoman.global.security.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
 import com.umc.naoman.global.security.util.CookieUtils;
 import com.umc.naoman.global.security.util.JwtUtils;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Collection;
 
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final JwtUtils jwtUtils;
     private final RefreshTokenService refreshTokenService;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final OAuth2AuthorizationRequestBasedOnCookieRepository
             oAuth2AuthorizationRequestBasedOnCookieRepository;
     @Value("${jwt.access-token-validity-in-seconds}")
     private Long ACCESS_TOKEN_VALIDITY_IN_SECONDS;
     @Value("${jwt.refresh-token-validity-in-seconds}")
     private Long REFRESH_TOKEN_VALIDITY_IN_SECONDS;
-
+    @Value("${jwt.temp-member-info-validity-in-seconds}")
+    private Long TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS;
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String REFRESH_TOKEN_KEY = "refresh_token";
+    private static final String TEMP_MEMBER_INFO_KEY = "temp_member_info";
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
-        String email = oAuth2User.getEmail();
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("해당 email을 가진 회원이 존재하지 않습니다."));
+        try { // 이미 회원가입된 회원인 경우
+            Member member = memberService.findMember(oAuth2User.getEmail());
+            handleExistingMemberLogin(request, response, oAuth2User, member);
+        } catch (BusinessException e) { // 회원가입되어 있지 않은 경우
+            handleMemberSignup(request, response, oAuth2User.getOAuthAttribute());
+        }
+    }
 
-        String role = oAuth2User.getAuthorities()
-                .iterator()
-                .next()
-                .getAuthority();
+    private void handleExistingMemberLogin(HttpServletRequest request, HttpServletResponse response,
+                                           OAuth2User oAuth2User, Member member) throws IOException {
+        String role;
+        Collection<? extends GrantedAuthority> authorities = oAuth2User.getAuthorities();
+        if (authorities.isEmpty()) { // role 자체가 할당되지 않은 경우 default 처리
+            role = "ROLE_DEFAULT";
+        } else {
+            role = oAuth2User.getAuthorities()
+                    .iterator()
+                    .next()
+                    .getAuthority();
+        }
 
-        // access token
-        String accessToken = jwtUtils.createJwt(email, role, ACCESS_TOKEN_VALIDITY_IN_SECONDS);
+        // 로그인 성공 처리를 위해 access token, refresh token 발급
+        String accessToken = jwtUtils.createJwt(member.getEmail(), role, ACCESS_TOKEN_VALIDITY_IN_SECONDS);
         CookieUtils.addCookie(response, AUTHORIZATION_HEADER, accessToken, ACCESS_TOKEN_VALIDITY_IN_SECONDS.intValue());
 
-        // refresh token
-        String refreshToken = jwtUtils.createJwt(email, role, REFRESH_TOKEN_VALIDITY_IN_SECONDS);
+        String refreshToken = jwtUtils.createJwt(member.getEmail(), role, REFRESH_TOKEN_VALIDITY_IN_SECONDS);
         refreshTokenService.saveRefreshToken(member.getId(), refreshToken);
         CookieUtils.addCookie(response, REFRESH_TOKEN_KEY, refreshToken, REFRESH_TOKEN_VALIDITY_IN_SECONDS.intValue());
+
+        clearAuthenticationAttributes(request, response);
+        // 프론트엔드 홈 화면으로 리다이렉션
+        response.sendRedirect("http://localhost:3000");
+    }
+
+    private void handleMemberSignup(HttpServletRequest request, HttpServletResponse response, OAuthAttribute oAuthAttribute)
+            throws IOException {
+        // Resource Server로부터 조회한 사용자 정보를 JWT로 직렬화 후, 쿠키로 담는다.
+        String tempUserInfo = jwtUtils.createJwt(oAuthAttribute, TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS);
+        CookieUtils.addCookie(response, TEMP_MEMBER_INFO_KEY, tempUserInfo, TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS.intValue());
 
         clearAuthenticationAttributes(request, response);
         // 약관 동의 화면으로 리다이렉션

--- a/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -83,8 +83,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private void handleMemberSignup(HttpServletRequest request, HttpServletResponse response, OAuthAttribute oAuthAttribute)
             throws IOException {
         // Resource Server로부터 조회한 사용자 정보를 JWT로 직렬화 후, 쿠키로 담는다.
-        String tempUserInfo = jwtUtils.createJwt(oAuthAttribute, TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS);
-        CookieUtils.addCookie(response, TEMP_MEMBER_INFO_KEY, tempUserInfo, TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS.intValue());
+        String tempMemberInfo = jwtUtils.createTempMemberInfoJwt(oAuthAttribute, TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS);
+        CookieUtils.addCookie(response, TEMP_MEMBER_INFO_KEY, tempMemberInfo, TEMP_MEMBER_INFO_VALIDITY_IN_SECONDS.intValue());
 
         clearAuthenticationAttributes(request, response);
         // 약관 동의 화면으로 리다이렉션

--- a/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,69 @@
+package com.umc.naoman.global.security.handler;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.repository.MemberRepository;
+import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
+import com.umc.naoman.global.security.model.CustomOAuth2User;
+import com.umc.naoman.global.security.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.umc.naoman.global.security.util.CookieUtils;
+import com.umc.naoman.global.security.util.JwtUtils;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtUtils jwtUtils;
+    private final RefreshTokenService refreshTokenService;
+    private final MemberRepository memberRepository;
+    private final OAuth2AuthorizationRequestBasedOnCookieRepository
+            oAuth2AuthorizationRequestBasedOnCookieRepository;
+    @Value("${jwt.access-token-validity-in-seconds}")
+    private Long ACCESS_TOKEN_VALIDITY_IN_SECONDS;
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private Long REFRESH_TOKEN_VALIDITY_IN_SECONDS;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String REFRESH_TOKEN_KEY = "refresh_token";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        String email = oAuth2User.getEmail();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("해당 email을 가진 회원이 존재하지 않습니다."));
+
+        String role = oAuth2User.getAuthorities()
+                .iterator()
+                .next()
+                .getAuthority();
+
+        // access token
+        String accessToken = jwtUtils.createJwt(email, role, ACCESS_TOKEN_VALIDITY_IN_SECONDS);
+        CookieUtils.addCookie(response, AUTHORIZATION_HEADER, accessToken, ACCESS_TOKEN_VALIDITY_IN_SECONDS.intValue());
+
+        // refresh token
+        String refreshToken = jwtUtils.createJwt(email, role, REFRESH_TOKEN_VALIDITY_IN_SECONDS);
+        refreshTokenService.saveRefreshToken(member.getId(), refreshToken);
+        CookieUtils.addCookie(response, REFRESH_TOKEN_KEY, refreshToken, REFRESH_TOKEN_VALIDITY_IN_SECONDS.intValue());
+
+        clearAuthenticationAttributes(request, response);
+        // 약관 동의 화면으로 리다이렉션
+        response.sendRedirect("http://localhost:3000/terms");
+    }
+
+    private void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        oAuth2AuthorizationRequestBasedOnCookieRepository.removeAuthorizationRequest(request, response);
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/model/CustomOAuth2User.java
+++ b/src/main/java/com/umc/naoman/global/security/model/CustomOAuth2User.java
@@ -16,7 +16,7 @@ public class CustomOAuth2User extends DefaultOAuth2User {
         this.oAuthAttribute = oAuthAttribute;
     }
 
-    public OAuthAttribute getoAuthAttribute() {
+    public OAuthAttribute getOAuthAttribute() {
         return oAuthAttribute;
     }
 

--- a/src/main/java/com/umc/naoman/global/security/model/CustomOAuth2User.java
+++ b/src/main/java/com/umc/naoman/global/security/model/CustomOAuth2User.java
@@ -1,0 +1,26 @@
+package com.umc.naoman.global.security.model;
+
+import com.umc.naoman.global.security.attribute.OAuthAttribute;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User extends DefaultOAuth2User {
+    private OAuthAttribute oAuthAttribute;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes,
+                            String nameAttributeKey, OAuthAttribute oAuthAttribute) {
+        super(authorities,attributes,nameAttributeKey);
+        this.oAuthAttribute = oAuthAttribute;
+    }
+
+    public OAuthAttribute getoAuthAttribute() {
+        return oAuthAttribute;
+    }
+
+    public String getEmail() {
+        return this.oAuthAttribute.getEmail();
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/model/MemberDetails.java
+++ b/src/main/java/com/umc/naoman/global/security/model/MemberDetails.java
@@ -1,0 +1,53 @@
+package com.umc.naoman.global.security.model;
+
+import com.umc.naoman.domain.member.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class MemberDetails implements UserDetails {
+    private final Member member;
+
+    public MemberDetails(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 나ㅇ만 서비스는 현재 Member 엔티티에게 권한이 존재하지 않음.
+        return Collections.emptyList();
+    }
+
+    @Override
+    @Deprecated
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/src/main/java/com/umc/naoman/global/security/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -1,0 +1,63 @@
+package com.umc.naoman.global.security.repository;
+
+import com.umc.naoman.global.security.util.CookieUtils;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.web.util.WebUtils;
+
+public class OAuth2AuthorizationRequestBasedOnCookieRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "OAuth2_AUTHORIZATION_REQUEST";
+    private final static int AUTHORIZATION_REQUEST_COOKIE_EXPIRE_SECONDS = 1800;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        String stateParameter = request.getParameter(OAuth2ParameterNames.STATE);
+        if (stateParameter == null) {
+            return null;
+        }
+
+        Cookie authorizationRequestCookie = WebUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        if (authorizationRequestCookie != null) {
+            OAuth2AuthorizationRequest authorizationRequest = CookieUtils.deserialize(authorizationRequestCookie,
+                    OAuth2AuthorizationRequest.class);
+
+            if (stateParameter.equals(authorizationRequest.getState())) {
+                return authorizationRequest;
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+                                         HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+
+        if (authorizationRequest.getState() == null) {
+            throw new IllegalArgumentException("authorizationRequest.state cannot be empty");
+        }
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                CookieUtils.serialize(authorizationRequest), AUTHORIZATION_REQUEST_COOKIE_EXPIRE_SECONDS);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                 HttpServletResponse response) {
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+        if (authorizationRequest != null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        }
+        return authorizationRequest;
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/umc/naoman/global/security/service/CustomOAuth2UserService.java
@@ -1,17 +1,14 @@
 package com.umc.naoman.global.security.service;
 
-import com.umc.naoman.domain.member.entity.Member;
-import com.umc.naoman.domain.member.repository.MemberRepository;
 import com.umc.naoman.global.security.attribute.OAuthAttribute;
 import com.umc.naoman.global.security.model.CustomOAuth2User;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.Map;
@@ -21,11 +18,8 @@ import java.util.Set;
  * OAuth 방식에 따라, 액세스 토큰을 바탕으로 사용자 정보를 조회하는 함수 loadUser()가 선언된 클래스
  */
 @Service
-@Transactional
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
-    private final MemberRepository memberRepository;
-
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         // Resource Server에서 사용자 정보를 조회한다.
@@ -38,20 +32,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (oAuthAttribute == null) {
             return null;
         }
-
-        Member member = saveOrUpdate(oAuthAttribute);
+        // 현재 서비스 정책 상 Member 엔티티 관련 권한은 존재하지 않으므로 emptySet()으로 처리
         Set<GrantedAuthority> authorities = Collections.emptySet();
 
         return new CustomOAuth2User(authorities, oAuthAttribute.getAttributes(),
                 oAuthAttribute.getUsernameAttributeKey(), oAuthAttribute);
-    }
-
-    // 이미 가입된 회원인지 판단 후, 결과에 따라 데이터 변경 및 저장 수행
-    public Member saveOrUpdate(OAuthAttribute oAuthAttribute) {
-        Member member = memberRepository.findByEmail(oAuthAttribute.getEmail())
-                .map(entity -> entity.update(oAuthAttribute.getName(), oAuthAttribute.getImage()))
-                .orElse(oAuthAttribute.toEntity());
-
-        return memberRepository.save(member);
     }
 }

--- a/src/main/java/com/umc/naoman/global/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/umc/naoman/global/security/service/CustomOAuth2UserService.java
@@ -1,0 +1,57 @@
+package com.umc.naoman.global.security.service;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.repository.MemberRepository;
+import com.umc.naoman.global.security.attribute.OAuthAttribute;
+import com.umc.naoman.global.security.model.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * OAuth 방식에 따라, 액세스 토큰을 바탕으로 사용자 정보를 조회하는 함수 loadUser()가 선언된 클래스
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // Resource Server에서 사용자 정보를 조회한다.
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> originAttributes = oAuth2User.getAttributes();
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        final OAuthAttribute oAuthAttribute = OAuthAttribute.of(registrationId, originAttributes);
+
+        if (oAuthAttribute == null) {
+            return null;
+        }
+
+        Member member = saveOrUpdate(oAuthAttribute);
+        Set<GrantedAuthority> authorities = Collections.emptySet();
+
+        return new CustomOAuth2User(authorities, oAuthAttribute.getAttributes(),
+                oAuthAttribute.getUsernameAttributeKey(), oAuthAttribute);
+    }
+
+    // 이미 가입된 회원인지 판단 후, 결과에 따라 데이터 변경 및 저장 수행
+    public Member saveOrUpdate(OAuthAttribute oAuthAttribute) {
+        Member member = memberRepository.findByEmail(oAuthAttribute.getEmail())
+                .map(entity -> entity.update(oAuthAttribute.getName(), oAuthAttribute.getImage()))
+                .orElse(oAuthAttribute.toEntity());
+
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/service/MemberDetailsService.java
+++ b/src/main/java/com/umc/naoman/global/security/service/MemberDetailsService.java
@@ -1,0 +1,28 @@
+package com.umc.naoman.global.security.service;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.member.repository.MemberRepository;
+import com.umc.naoman.global.security.model.MemberDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * JWT를 헤더로 세팅하여 요청이 들어왔을 때,
+ * JwtAuthenticationFilter -> JwtUtils의 getAuthentication(String token)
+ * -> loadUserByUsername(String username) 호출을 통해 DB에 저장된 회원인지 확인하는 클래스
+ */
+@Service
+@RequiredArgsConstructor
+public class MemberDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 회원이 존재하지 않습니다."));
+
+        return new MemberDetails(member);
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
@@ -1,0 +1,45 @@
+package com.umc.naoman.global.security.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.SerializationUtils;
+import org.springframework.web.util.WebUtils;
+
+import java.io.Serializable;
+import java.util.Base64;
+
+public class CookieUtils {
+
+    public static void addCookie(HttpServletResponse response, String name, String value,
+                                 int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        // HTTPS 적용 시 함께 적용
+        // cookie.setSecure(true);
+        // cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,
+                                    String name) {
+        Cookie targetCookie = WebUtils.getCookie(request, name);
+        if (targetCookie != null) {
+            Cookie cookie = new Cookie(targetCookie.getName(), null);
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+        }
+    }
+
+    // 객체를 직렬화(Object -> String)해 쿠키 값으로 변환
+    public static String serialize(Object obj) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize((Serializable) obj));
+    }
+
+    // 쿠키를 역직렬화(String -> Object)해 객체로 변환
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
@@ -10,7 +10,6 @@ import java.io.Serializable;
 import java.util.Base64;
 
 public class CookieUtils {
-
     public static void addCookie(HttpServletResponse response, String name, String value,
                                  int maxAge) {
         Cookie cookie = new Cookie(name, value);

--- a/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
@@ -78,7 +78,7 @@ public class JwtUtils {
                 .compact();
     }
 
-    public String createJwt(OAuthAttribute oAuthAttribute, Long seconds) {
+    public String createTempMemberInfoJwt(OAuthAttribute oAuthAttribute, Long seconds) {
         final LocalDateTime now = LocalDateTime.now();
         final Date issuedDate = localDateTimeToDate(now);
         final Date expiredDate = localDateTimeToDate(now.plusSeconds(seconds));
@@ -88,6 +88,7 @@ public class JwtUtils {
                 .claim("name", oAuthAttribute.getName())
                 .claim("image", oAuthAttribute.getImage())
                 .claim("socialType", oAuthAttribute.getProvider())
+                .claim("authId", oAuthAttribute.getAuthId())
                 .issuedAt(issuedDate)
                 .expiration(expiredDate)
                 .signWith(secretKey)

--- a/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
@@ -1,7 +1,9 @@
 package com.umc.naoman.global.security.util;
 
+import com.umc.naoman.global.security.attribute.OAuthAttribute;
 import com.umc.naoman.global.security.model.MemberDetails;
 import com.umc.naoman.global.security.service.MemberDetailsService;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -18,6 +20,7 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 @Component
 public class JwtUtils {
@@ -44,6 +47,14 @@ public class JwtUtils {
                 .get(PAYLOAD_EMAIL_KEY, String.class);
     }
 
+    public Claims getPayload(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
     public Boolean isExpired(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
@@ -61,6 +72,22 @@ public class JwtUtils {
         return Jwts.builder()
                 .claim(PAYLOAD_EMAIL_KEY, email)
                 .claim(PAYLOAD_ROLE_KEY, role)
+                .issuedAt(issuedDate)
+                .expiration(expiredDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createJwt(OAuthAttribute oAuthAttribute, Long seconds) {
+        final LocalDateTime now = LocalDateTime.now();
+        final Date issuedDate = localDateTimeToDate(now);
+        final Date expiredDate = localDateTimeToDate(now.plusSeconds(seconds));
+
+        return Jwts.builder()
+                .claim(PAYLOAD_EMAIL_KEY, oAuthAttribute.getEmail())
+                .claim("name", oAuthAttribute.getName())
+                .claim("image", oAuthAttribute.getImage())
+                .claim("socialType", oAuthAttribute.getProvider())
                 .issuedAt(issuedDate)
                 .expiration(expiredDate)
                 .signWith(secretKey)

--- a/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
@@ -1,0 +1,83 @@
+package com.umc.naoman.global.security.util;
+
+import com.umc.naoman.global.security.model.MemberDetails;
+import com.umc.naoman.global.security.service.MemberDetailsService;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class JwtUtils {
+    private final SecretKey secretKey;
+    private final MemberDetailsService memberDetailsService;
+
+    // "HMACSHA256" 알고리즘명을 저장
+    private static final String SIGNATURE_ALGORITHM = Jwts.SIG.HS256.key().build().getAlgorithm();
+    private static final String PAYLOAD_MEMBER_ID_KEY = "memberId";
+    private static final String PAYLOAD_EMAIL_KEY = "email";
+    private static final String PAYLOAD_ROLE_KEY = "role";
+
+    JwtUtils(@Value("${jwt.secret}") String secret, MemberDetailsService memberDetailsService) {
+        this.memberDetailsService = memberDetailsService;
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), SIGNATURE_ALGORITHM);
+    }
+
+    public String getEmail(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get(PAYLOAD_EMAIL_KEY, String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration().before(new Date());
+    }
+
+    public String createJwt(String email, String role, Long seconds) {
+        final LocalDateTime now = LocalDateTime.now();
+        final Date issuedDate = localDateTimeToDate(now);
+        final Date expiredDate = localDateTimeToDate(now.plusSeconds(seconds));
+
+        return Jwts.builder()
+                .claim(PAYLOAD_EMAIL_KEY, email)
+                .claim(PAYLOAD_ROLE_KEY, role)
+                .issuedAt(issuedDate)
+                .expiration(expiredDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        // 나ㅇ만 서비스는 현재 Member 엔티티에게 권한이 존재하지 않으므로 authorities는 빈 리스트 처리
+        final List<SimpleGrantedAuthority> authorities = Collections.emptyList();
+
+        // 사용자 정의로 구현한 MemberDetails 사용
+        final MemberDetails principal = memberDetailsService.loadUserByUsername(getEmail(token));
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    private Date localDateTimeToDate(LocalDateTime localDateTime) {
+        Instant instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
+        return Date.from(instant);
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/JwtUtils.java
@@ -20,7 +20,6 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 @Component
 public class JwtUtils {


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #2 

## 📝 작업 내용
카카오, 구글을 통한 소셜 로그인/회원가입 기능을 구현하였습니다.
Swagger 세팅을 진행하였습니다.

## 💭 상세 설명
안드로이드 클라이언트와 웹 클라이언트의 회원가입/로그인 플로우가 달라 분리하여 구현하였습니다.

### 웹
웹의 경우 소셜 로그인 버튼을 클릭 시
`OAuth2AuthorizationRequestRedirectFilter`(라이브러리) -> `OAuth2LoginAuthenticationFilter`(라이브러리) -> `OAuth2LoginSuccessHandler`(직접 구현) 플로우를 거쳐 OAuth 프로토콜에 따라 사용자 정보를 조회합니다.
서비스 자체 약관 페이지로 리다이렉트하여 약관 여부까지 전달받아야 회원가입을 완료할 수 있기 때문에, `OAuth2LoginSuccessHandler`에서 회원가입 여부를 확인하여
- 이미 회원가입되어 있는 경우 access token을 발급
- 회원가입되어 있지 않은 경우 약관 페이지로 리다이렉션
2가지 중 한 쪽으로 분기합니다.

약관 페이지로 리다이렉션 시에는 `Resource Server`로부터 조회한 사용자 정보를 JWT로 직렬화하여 쿠키로 담아 이후 회원가입 API 호출 시 데이터를 이용할 수 있도록 합니다. (회원가입 API의 경우, `/auth/signup/web` URI로 별도 구현됨)

### 안드로이드
안드로이드의 경우 SDK 방식을 통해 소셜 로그인을 진행하므로, 서버와의 통신 없이 직접 `Resource Server`로부터 사용자 정보 조회 후, 약관 페이지로 이동해 약관 동의 여부도 확인할 수 있습니다.
이때, 약관 페이지로 이동하기 전 조회한 사용자 정보를 통해 해당 사용자가 이미 우리 서비스에 가입된 회원인지 확인합니다. 이때 호출하는 API는 `/auth/check-registration`입니다.

해당 API의 응답 결과를 통해 확인한 가입 여부에 따라 2가지 방향으로 나뉩니다.
- 이미 가입된 경우 -> `/auth/login/android` 로그인 API 호출(JWT 발급 위함)
- 가입되어 있지 않은 경우 -> 약관 동의 페이지로 이동하여 회원가입 플로우 진행

이미 가입된 경우 조회한 사용자 정보에서 회원 id(카카오는 `id`, 구글은 `sub`)와 `socialType`으로 `/auth/login/android` 로그인 API를 호출합니다.

이미 가입되지 않은 경우 안드로이드는 웹과 달리 자신이 직접 조회한 사용자 정보와 약관 동의 여부를 Request Body에 담아 바로 `/auth/signup/android` URI의 회원가입 API를 호출합니다.


## 💡 리뷰 포인트