### PR TITLE
[FEAT] 특정 회원 정보 조회 api

### DIFF
--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -1,8 +1,15 @@
 package com.umc.naoman.domain.member.controller;
 
+import com.umc.naoman.domain.member.converter.MemberConverter;
+import com.umc.naoman.domain.member.dto.MemberResponse;
+import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.service.MemberService;
+import com.umc.naoman.global.result.ResultResponse;
+import com.umc.naoman.global.result.code.MemberResultCode;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+
+    @GetMapping("/{memberId}") // memberId를 사용해 특정 회원 정보 조회
+    public ResultResponse<MemberResponse.MemberInfo> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
+        Member member = memberService.findMember(memberId);
+        return ResultResponse.of(MemberResultCode.MEMBER_INFO,
+                MemberConverter.toMemberInfo(member));
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
@@ -1,6 +1,7 @@
 package com.umc.naoman.domain.member.converter;
 
 import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
+import com.umc.naoman.domain.member.dto.MemberResponse;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.entity.SocialType;
@@ -36,6 +37,14 @@ public class MemberConverter {
                 .socialType(SocialType.valueOf(payload.get("socialType", String.class)))
                 .authId(payload.get("authId", String.class))
                 .marketingAgreed(marketingAgreed)
+                .build();
+    }
+
+    public static MemberResponse.MemberInfo toMemberInfo(Member member) {
+        return MemberResponse.MemberInfo.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .image(member.getImage())
                 .build();
     }
 

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
@@ -25,4 +25,13 @@ public abstract class MemberResponse {
         private String accessToken;
         private String refreshToken;
     }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class MemberInfo { //특정 회원 조회
+        private String name;
+        private String email;
+        private String image;
+    }
 }

--- a/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
@@ -12,7 +12,7 @@ public enum MemberResultCode implements ResultCode {
     MYPAGE_INFO(200, "SM001", "내 정보를 성공적으로 조회하였습니다."),
     EDIT_MYPAGE_INFO(200, "SM002", "내 정보를 성공적으로 수정하였습니다."),
     CHECK_MEMBER_REGISTRATION(200, "SM000", "해당 이메일을 가진 회원의 가입 여부를 성공적으로 조회하였습니다."),
-
+    MEMBER_INFO (200,"SM005","회원 정보를 성공적으로 조회하였습니다."),
     ;
     private final int status;
     private final String code;


### PR DESCRIPTION
## ❗️ 이슈 번호
#12  

## 📝 작업 내용
특정 회원 정보 조회 api 구현
## 💭 주의 사항
1. 현재 서비스에서는 사용하는 기능이 없지만 차후 관리자 페이지등 확장성을 고려하여 구현하였습니다.
## 💡 리뷰 포인트
1. memberId를 통해 특정 회원의 정보를 조회하는 api입니다.
2. member의 name, email, 소셜프로필 이미지 url을 반환합니다.