### PR TITLE
[FEAT] 마케팅 이용약관 동의 여부 조회 api 구현

### DIFF
--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -4,8 +4,14 @@ import com.umc.naoman.domain.member.converter.MemberConverter;
 import com.umc.naoman.domain.member.dto.MemberResponse;
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.service.MemberService;
+import com.umc.naoman.global.error.ErrorResponse;
 import com.umc.naoman.global.result.ResultResponse;
 import com.umc.naoman.global.result.code.MemberResultCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +26,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
+
     @GetMapping("/{memberId}") // memberId를 사용해 특정 회원 정보 조회
+    @Operation( summary = "특정 회원 정보 조회 API", description = "PathVariable]\n memberId\nrequest]\n" +
+            "response]\n uesrname, email, 소셜 프로필 이미지 url")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse
+                    (responseCode = "SM005", description = "특정 회원 정보 조회 성공."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse
+                    (responseCode = "EM001", description = "해당 memberId를 가진 회원이 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     public ResultResponse<MemberResponse.MemberInfo> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
         Member member = memberService.findMember(memberId);
         return ResultResponse.of(MemberResultCode.MEMBER_INFO,
@@ -28,6 +44,15 @@ public class MemberController {
     }
 
     @GetMapping("/terms/{memberId}")
+    @Operation(summary = "마케팅 약관 동의 여부 조회 API", description = "PathVariable]\n memberId\nrequest]\n" +
+            "response]\n 마케팅 동의 여부 -> 동의 => true, 비동의 => false")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse
+                    (responseCode = "SM006", description = "마케팅 약관 동의 여부 조회 성공."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse
+                    (responseCode = "EM001", description = "해당 memberId를 가진 회원이 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     public ResultResponse<MemberResponse.MarketingAgreed> getMarketingAgreed(@PathVariable(name = "memberId") Long memberId) {
         Member member = memberService.findMember(memberId);
         return ResultResponse.of(MemberResultCode.CHECK_MARKETING_AGREED, MemberConverter.toMarketingAgreed(member));

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -10,7 +10,6 @@ import com.umc.naoman.global.result.code.MemberResultCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +27,8 @@ public class MemberController {
 
 
     @GetMapping("/{memberId}") // memberId를 사용해 특정 회원 정보 조회
-    @Operation( summary = "특정 회원 정보 조회 API", description = "PathVariable]\n memberId\nrequest]\n" +
-            "response]\n uesrname, email, 소셜 프로필 이미지 url")
+    @Operation( summary = "특정 회원 정보 조회 API", description = "[PathVariable]\n memberId\n[request]\n" +
+            "[response]\n uesrname, email, 소셜 프로필 이미지 url")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse
                     (responseCode = "SM005", description = "특정 회원 정보 조회 성공."),
@@ -44,8 +43,8 @@ public class MemberController {
     }
 
     @GetMapping("/terms/{memberId}")
-    @Operation(summary = "마케팅 약관 동의 여부 조회 API", description = "PathVariable]\n memberId\nrequest]\n" +
-            "response]\n 마케팅 동의 여부 -> 동의 => true, 비동의 => false")
+    @Operation(summary = "마케팅 약관 동의 여부 조회 API", description = "[PathVariable]\n memberId\n[request]\n" +
+            "[response]\n 마케팅 동의 여부 -> 동의 => true, 비동의 => false")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse
                     (responseCode = "SM006", description = "마케팅 약관 동의 여부 조회 성공."),

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -26,4 +26,10 @@ public class MemberController {
         return ResultResponse.of(MemberResultCode.MEMBER_INFO,
                 MemberConverter.toMemberInfo(member));
     }
+
+    @GetMapping("/terms/{memberId}")
+    public ResultResponse<MemberResponse.MarketingAgreed> getMarketingAgreed(@PathVariable(name = "memberId") Long memberId) {
+        Member member = memberService.findMember(memberId);
+        return ResultResponse.of(MemberResultCode.CHECK_MARKETING_AGREED, MemberConverter.toMarketingAgreed(member));
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
-
+    private final MemberConverter memberConverter;
 
     @GetMapping("/{memberId}") // memberId를 사용해 특정 회원 정보 조회
     @Operation( summary = "특정 회원 정보 조회 API", description = "[PathVariable]\n memberId\n[request]\n" +
@@ -39,7 +39,7 @@ public class MemberController {
     public ResultResponse<MemberResponse.MemberInfo> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
         Member member = memberService.findMember(memberId);
         return ResultResponse.of(MemberResultCode.MEMBER_INFO,
-                MemberConverter.toMemberInfo(member));
+                memberConverter.toMemberInfo(member));
     }
 
     @GetMapping("/terms/{memberId}")
@@ -54,6 +54,6 @@ public class MemberController {
     })
     public ResultResponse<MemberResponse.MarketingAgreed> getMarketingAgreed(@PathVariable(name = "memberId") Long memberId) {
         Member member = memberService.findMember(memberId);
-        return ResultResponse.of(MemberResultCode.CHECK_MARKETING_AGREED, MemberConverter.toMarketingAgreed(member));
+        return ResultResponse.of(MemberResultCode.CHECK_MARKETING_AGREED, memberConverter.toMarketingAgreed(member));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
@@ -48,4 +48,10 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResponse.MarketingAgreed toMarketingAgreed(Member member) {
+        return MemberResponse.MarketingAgreed.builder()
+                .marketingAgreed(member.getMarketingAgreed())
+                .build();
+    }
+
 }

--- a/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/naoman/domain/member/converter/MemberConverter.java
@@ -40,7 +40,7 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponse.MemberInfo toMemberInfo(Member member) {
+    public MemberResponse.MemberInfo toMemberInfo(Member member) {
         return MemberResponse.MemberInfo.builder()
                 .name(member.getName())
                 .email(member.getEmail())
@@ -48,7 +48,7 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponse.MarketingAgreed toMarketingAgreed(Member member) {
+    public MemberResponse.MarketingAgreed toMarketingAgreed(Member member) {
         return MemberResponse.MarketingAgreed.builder()
                 .marketingAgreed(member.getMarketingAgreed())
                 .build();

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberResponse.java
@@ -34,4 +34,11 @@ public abstract class MemberResponse {
         private String email;
         private String image;
     }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class MarketingAgreed {
+        private Boolean marketingAgreed;
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/Member.java
@@ -39,7 +39,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "social_type", nullable = false)
     private SocialType socialType;
     @Column(name = "marketing_agreed")
-    private boolean marketingAgreed;
+    private Boolean marketingAgreed;
 
     public Member update(String name, String image) {
         this.name = name;

--- a/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
@@ -13,7 +13,7 @@ public enum MemberResultCode implements ResultCode {
     EDIT_MYPAGE_INFO(200, "SM002", "내 정보를 성공적으로 수정하였습니다."),
     CHECK_MEMBER_REGISTRATION(200, "SM000", "해당 이메일을 가진 회원의 가입 여부를 성공적으로 조회하였습니다."),
     MEMBER_INFO (200,"SM005","회원 정보를 성공적으로 조회하였습니다."),
-    CHECK_MARKETING_AGREED(200,"SM006","마케팅 동의 여부를 성공적으로 조회하였습니다."),
+    CHECK_MARKETING_AGREED(200,"SM006","마케팅동의여부를 성공적으로 조회하였습니다."),
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
@@ -13,6 +13,7 @@ public enum MemberResultCode implements ResultCode {
     EDIT_MYPAGE_INFO(200, "SM002", "내 정보를 성공적으로 수정하였습니다."),
     CHECK_MEMBER_REGISTRATION(200, "SM000", "해당 이메일을 가진 회원의 가입 여부를 성공적으로 조회하였습니다."),
     MEMBER_INFO (200,"SM005","회원 정보를 성공적으로 조회하였습니다."),
+    CHECK_MARKETING_AGREED(200,"SM006","마케팅 동의 여부를 성공적으로 조회하였습니다."),
     ;
     private final int status;
     private final String code;


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#14 

## 📝 작업 내용
해당 회원의 마케팅 이용약관 동의 여부를 조회하는 api 구현
## 💭 주의 사항
1. 동의 약관을 동의한 회원의 경우 True(or 1), 동의하지 않은 경우 False(or 0)을 반환 
## 💡 리뷰 포인트
1. 엔드포인트가 /members/terms/{memberId}로 했는데 약관 여부를 확인하기 때문에 terms로 했지만 직관성이 떨어지면 marketing 혹은 marketingAgreed로 변경하겠습니다.