### PR TITLE
[FIX] 프로필 이미지 컬럼 크기 변경, 약관 동의화면 경로 변경, CORS 설정

### DIFF
--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
     private final MemberService memberService;
 
     @PostMapping("/signup/web")
-    @Operation(summary = "회원가입 API(웹)", description = "웹 클라이언트가 사용하는 회원가입 요청 API입니다.")
+    @Operation(summary = "회원가입 API(웹)", description = "웹 클라이언트가 사용하는 회원가입 API입니다.")
     @Parameters(value = {
             @Parameter(name = "temp-member-info", description = "리다이렉션 시에 쿠키로 넘겨준 사용자 정보가 담긴 jwt를 헤더로 넘겨주세요.",
                     in = ParameterIn.HEADER)

--- a/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/umc/naoman/domain/member/dto/MemberRequest.java
@@ -42,10 +42,9 @@ public abstract class MemberRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LoginRequest {
-        @NotNull(message = "로그인한 소셜 플랫폼에서 제공한 회원 번호를 필수로 입력해야 합니다.")
-        private String authId;
         @NotNull(message = "socialType은 KAKAO, GOOGLE 중 하나를 입력해야 합니다.")
         private SocialType socialType;
-
+        @NotNull(message = "로그인한 소셜 플랫폼에서 제공한 회원 번호를 필수로 입력해야 합니다.")
+        private String authId;
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/naoman/domain/member/entity/Member.java
@@ -32,6 +32,7 @@ public class Member extends BaseTimeEntity {
     private String email;
     @Column(nullable = false)
     private String name;
+    @Column(length = 2000)
     private String image;
     @Column(name = "auth_id", nullable = false)
     private String authId;

--- a/src/main/java/com/umc/naoman/domain/shareGroup/entity/Profile.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/entity/Profile.java
@@ -39,6 +39,7 @@ public class Profile {
     private Long id;
     @Column(nullable = false)
     private String name;
+    @Column(length = 2000)
     private String image;
     @Enumerated(EnumType.STRING)
     private Role role;

--- a/src/main/java/com/umc/naoman/global/config/SwaggerConfig.java
+++ b/src/main/java/com/umc/naoman/global/config/SwaggerConfig.java
@@ -22,7 +22,7 @@ public class SwaggerConfig {
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
         Server server = new Server();
-        server.setUrl("https://www.naoman.site");
+        server.setUrl("https://naoman.site");
 
         Server local = new Server();
         local.setUrl("http://localhost:8080");

--- a/src/main/java/com/umc/naoman/global/config/SwaggerConfig.java
+++ b/src/main/java/com/umc/naoman/global/config/SwaggerConfig.java
@@ -22,7 +22,7 @@ public class SwaggerConfig {
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
         Server server = new Server();
-        server.setUrl("http://52.79.212.19");
+        server.setUrl("https://www.naoman.site");
 
         Server local = new Server();
         local.setUrl("http://localhost:8080");

--- a/src/main/java/com/umc/naoman/global/config/WebMvcConfig.java
+++ b/src/main/java/com/umc/naoman/global/config/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package com.umc.naoman.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowCredentials(true)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -40,8 +40,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String REFRESH_TOKEN_KEY = "refresh-token";
     private static final String TEMP_MEMBER_INFO_KEY = "temp-member-info";
-    private static final String FRONTEND_BASE_URL = "http://localhost:3000";
-    private static final String FRONTEND_AGREEMENT_PATH = "/enter/login/clause";
+    private static final String FRONTEND_BASE_URL = "https://www.naver.com";
+    private static final String FRONTEND_AGREEMENT_PATH = "/login/clause";
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #29 

## 📝 작업 내용
`Member`, `Profile` 엔티티의 image 필드에 소셜 플랫폼에서 조회한 이미지 url이 저장될 수 있도록 `@Column(length = 2000)`와 같이 length 속성을 사용하였습니다.

`OAuth2LoginSuccessHandler` 클래스의 약관 동의화면 경로 변수 `FRONTEND_AGREEMENT_PATH`의 값을 웹 프론트엔드의 요청에 따라 `/login/clause`로 변경하였습니다.

`WebMvcConfig` 클래스를 생성 후, `addCorsMappings()` 함수를 통해 CORS 설정을 하였습니다. 추후 프론트엔드 도메인이 확정될 시, `allowedOriginPatterns()` 의 파라미터를 변경할 예정입니다.

## 💭 주의 사항

## 💡 리뷰 포인트