### PR TITLE
[FEAT] 특정 사진 삭제 API 구현

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -1,17 +1,20 @@
 package com.umc.naoman.domain.photo.controller;
 
+import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.photo.converter.PhotoConverter;
 import com.umc.naoman.domain.photo.dto.PhotoRequest;
 import com.umc.naoman.domain.photo.dto.PhotoResponse;
 import com.umc.naoman.domain.photo.entity.Photo;
 import com.umc.naoman.domain.photo.service.PhotoService;
 import com.umc.naoman.global.result.ResultResponse;
+import com.umc.naoman.global.security.annotation.LoginMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,8 +35,9 @@ public class PhotoController {
     private final PhotoConverter photoConverter;
 
     @PostMapping("/preSignedUrl")
-    public ResultResponse<PhotoResponse.PreSignedUrlListInfo> getPreSignedUrlList(@Valid @RequestBody PhotoRequest.PreSignedUrlRequest request) {
-        List<PhotoResponse.PreSignedUrlInfo> preSignedUrlList = photoService.getPreSignedUrlList(request);
+    public ResultResponse<PhotoResponse.PreSignedUrlListInfo> getPreSignedUrlList(@Valid @RequestBody PhotoRequest.PreSignedUrlRequest request,
+                                                                                  @LoginMember Member member) {
+        List<PhotoResponse.PreSignedUrlInfo> preSignedUrlList = photoService.getPreSignedUrlList(request, member);
         return ResultResponse.of(CREATE_PRESIGNED_URL, photoConverter.toPreSignedUrlListInfo(preSignedUrlList));
     }
 
@@ -44,10 +48,16 @@ public class PhotoController {
     }
 
     @GetMapping("/all")
-    public ResultResponse<PhotoResponse.PagedPhotoInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId,
-                                                                                   @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<Photo> allPhotoListByShareGroup = photoService.getAllPhotoList(shareGroupId, pageable);
+    public ResultResponse<PhotoResponse.PagedPhotoInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId, @LoginMember Member member,
+                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Photo> allPhotoListByShareGroup = photoService.getAllPhotoList(shareGroupId, member, pageable);
         return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPhotoListInfo(allPhotoListByShareGroup));
     }
 
+    @DeleteMapping
+    public ResultResponse<PhotoResponse.PhotoDeleteInfo> deletePhotoList(@Valid @RequestBody PhotoRequest.PhotoDeletedRequest request,
+                                                                         @LoginMember Member member) {
+        List<Photo> photoList = photoService.deletePhotoList(request, member);
+        return ResultResponse.of(DELETE_PHOTO, photoConverter.toPhotoDeleteInfo(photoList));
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -42,8 +42,9 @@ public class PhotoController {
     }
 
     @PostMapping("/upload")
-    public ResultResponse<PhotoResponse.PhotoUploadInfo> uploadPhotoList(@Valid @RequestBody PhotoRequest.PhotoUploadRequest request) {
-        PhotoResponse.PhotoUploadInfo photoUploadInfo = photoService.uploadPhotoList(request);
+    public ResultResponse<PhotoResponse.PhotoUploadInfo> uploadPhotoList(@Valid @RequestBody PhotoRequest.PhotoUploadRequest request,
+                                                                         @LoginMember Member member) {
+        PhotoResponse.PhotoUploadInfo photoUploadInfo = photoService.uploadPhotoList(request, member);
         return ResultResponse.of(UPLOAD_PHOTO, photoUploadInfo);
     }
 

--- a/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
+++ b/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.umc.naoman.domain.photo.service.PhotoServiceImpl.*;
+
 @Component
 public class PhotoConverter {
 
@@ -61,8 +63,8 @@ public class PhotoConverter {
 
         return PhotoResponse.PhotoInfo.builder()
                 .rawPhotoUrl(rawUrl)
-                .w200PhotoUrl(createResizedPhotoUrl(rawUrl, "w200"))
-                .w400PhotoUrl(createResizedPhotoUrl(rawUrl, "w400"))
+                .w200PhotoUrl(createResizedPhotoUrl(rawUrl, W200_PATH_PREFIX))
+                .w400PhotoUrl(createResizedPhotoUrl(rawUrl, W400_PATH_PREFIX))
                 .createdAt(photo.getCreatedAt())
                 .build();
     }
@@ -74,12 +76,22 @@ public class PhotoConverter {
 
     // 리사이즈된 사진의 URL로 변환하는 메서드
     private String getResizedUrl(String photoUrl, String size) {
-        return photoUrl.replace("/raw/", "/" + size + "/");
+        return photoUrl.replace("/" + RAW_PATH_PREFIX + "/", "/" + size + "/");
     }
 
     // 확장자 변환 메서드
-    private String convertExtension(String photoUrl) {
+    public String convertExtension(String photoUrl) {
         return photoUrl.replace(".HEIC", ".jpg");
+    }
+
+    public PhotoResponse.PhotoDeleteInfo toPhotoDeleteInfo(List<Photo> photoList) {
+        List<Long> photoIdList = photoList.stream()
+                .map(Photo::getId)
+                .collect(Collectors.toList());
+
+        return PhotoResponse.PhotoDeleteInfo.builder()
+                .photoIdList(photoIdList)
+                .build();
     }
 
 }

--- a/src/main/java/com/umc/naoman/domain/photo/dto/PhotoRequest.java
+++ b/src/main/java/com/umc/naoman/domain/photo/dto/PhotoRequest.java
@@ -17,6 +17,8 @@ public abstract class PhotoRequest {
     @AllArgsConstructor
     public static class PreSignedUrlRequest {
 
+        @NotNull(message = "공유 그룹의 아이디 값을 입력해야 합니다.")
+        private Long shareGroupId;
         @NotEmpty(message = "사진의 이름은 하나 이상이어야 합니다.")
         private List<String> photoNameList;
 
@@ -34,4 +36,15 @@ public abstract class PhotoRequest {
         private List<String> photoUrlList;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PhotoDeletedRequest {
+
+        @NotNull(message = "삭제할 사진이 존재하는 공유 그룹의 아이디 값을 입력해야 합니다.")
+        private Long shareGroupId;
+        @NotEmpty(message = "삭제할 사진을 하나 이상 선택해야 합니다.")
+        private List<Long> photoIdList;
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/photo/dto/PhotoResponse.java
+++ b/src/main/java/com/umc/naoman/domain/photo/dto/PhotoResponse.java
@@ -59,4 +59,13 @@ public abstract class PhotoResponse {
         private String w400PhotoUrl;
         private LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PhotoDeleteInfo {
+        private List<Long> photoIdList;
+    }
+
 }

--- a/src/main/java/com/umc/naoman/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/umc/naoman/domain/photo/repository/PhotoRepository.java
@@ -1,13 +1,15 @@
 package com.umc.naoman.domain.photo.repository;
 
 import com.umc.naoman.domain.photo.entity.Photo;
-import com.umc.naoman.domain.shareGroup.entity.ShareGroup;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
     Page<Photo> findAllByShareGroupId(Long shareGroupId, Pageable pageable);
+    List<Photo> findByIdInAndShareGroupId(List<Long> photoIdList, Long shareGroupId);
 }

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -13,7 +13,7 @@ public interface PhotoService {
 
     List<PhotoResponse.PreSignedUrlInfo> getPreSignedUrlList(PhotoRequest.PreSignedUrlRequest request, Member member);
 
-    PhotoResponse.PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request);
+    PhotoResponse.PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request, Member member);
 
     Page<Photo> getAllPhotoList(Long shareGroupId, Member member, Pageable pageable);
 

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -1,5 +1,6 @@
 package com.umc.naoman.domain.photo.service;
 
+import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.photo.dto.PhotoRequest;
 import com.umc.naoman.domain.photo.dto.PhotoResponse;
 import com.umc.naoman.domain.photo.entity.Photo;
@@ -10,9 +11,11 @@ import java.util.List;
 
 public interface PhotoService {
 
-    List<PhotoResponse.PreSignedUrlInfo> getPreSignedUrlList(PhotoRequest.PreSignedUrlRequest request);
+    List<PhotoResponse.PreSignedUrlInfo> getPreSignedUrlList(PhotoRequest.PreSignedUrlRequest request, Member member);
 
     PhotoResponse.PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request);
 
-    Page<Photo> getAllPhotoList(Long shareGroupId, Pageable pageable);
+    Page<Photo> getAllPhotoList(Long shareGroupId, Member member, Pageable pageable);
+
+    List<Photo> deletePhotoList(PhotoRequest.PhotoDeletedRequest request, Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -115,7 +115,11 @@ public class PhotoServiceImpl implements PhotoService {
 
     @Override
     @Transactional
-    public PhotoResponse.PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request) {
+    public PhotoResponse.PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request, Member member) {
+        if (profileRepository.findByShareGroupIdAndMemberId(request.getShareGroupId(), member.getId()) == null) {
+            throw new BusinessException(UNAUTHORIZED_UPLOAD);
+        }
+
         ShareGroup shareGroup = shareGroupService.findShareGroup(request.getShareGroupId());
         int uploadCount = 0;
 

--- a/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
     List<Profile> findByShareGroupId(Long shareGroupId);
+    Profile findByShareGroupIdAndMemberId(Long shareGroupId, Long memberId);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
@@ -5,9 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
     List<Profile> findByShareGroupId(Long shareGroupId);
-    Profile findByShareGroupIdAndMemberId(Long shareGroupId, Long memberId);
+    Optional<Profile> findByShareGroupIdAndMemberId(Long shareGroupId, Long memberId);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
@@ -13,4 +13,5 @@ public interface ShareGroupService {
     List<Profile> findProfileList(Long shareGroupId);
     ShareGroup joinShareGroup(Long shareGroupId, Long profileId, Member member);
     Profile findProfile(Long profileId);
+    Profile findProfile(Long shareGroupId, Long memberID);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -10,7 +10,6 @@ import com.umc.naoman.domain.shareGroup.entity.ShareGroup;
 import com.umc.naoman.domain.shareGroup.repository.ProfileRepository;
 import com.umc.naoman.domain.shareGroup.repository.ShareGroupRepository;
 import com.umc.naoman.global.error.BusinessException;
-import com.umc.naoman.global.error.code.MemberErrorCode;
 import com.umc.naoman.global.error.code.ShareGroupErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -97,6 +96,12 @@ public class ShareGroupServiceImpl implements ShareGroupService {
     @Override
     public Profile findProfile(Long profileId) {
         return profileRepository.findById(profileId)
+                .orElseThrow(() -> new BusinessException(ShareGroupErrorCode.PROFILE_NOT_FOUND));
+    }
+
+    @Override
+    public Profile findProfile(Long shareGroupId, Long memberId) {
+        return profileRepository.findByShareGroupIdAndMemberId(shareGroupId, memberId)
                 .orElseThrow(() -> new BusinessException(ShareGroupErrorCode.PROFILE_NOT_FOUND));
     }
 

--- a/src/main/java/com/umc/naoman/global/error/code/S3ErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/S3ErrorCode.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 public enum S3ErrorCode implements ErrorCode {
     FAILED_UPLOAD_S3(500, "ES3000", "S3에 업로드를 실패하였습니다."),
     PHOTO_NOT_FOUND_S3(404, "ES3000", "S3에서 파일을 찾을 수 없습니다."),
+    UNAUTHORIZED_GET(403, "ES3000", "사진을 조회할 권한이 없습니다."),
+    UNAUTHORIZED_DELETE(403, "ES3000", "사진을 삭제할 권한이 없습니다."),
+    UNAUTHORIZED_UPLOAD(403, "ES3000", "사진을 업로드할 권한이 없습니다."),
 
     ;
 

--- a/src/main/java/com/umc/naoman/global/error/code/S3ErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/S3ErrorCode.java
@@ -12,6 +12,7 @@ public enum S3ErrorCode implements ErrorCode {
     UNAUTHORIZED_GET(403, "ES3000", "사진을 조회할 권한이 없습니다."),
     UNAUTHORIZED_DELETE(403, "ES3000", "사진을 삭제할 권한이 없습니다."),
     UNAUTHORIZED_UPLOAD(403, "ES3000", "사진을 업로드할 권한이 없습니다."),
+    PHOTO_NOT_FOUND(404, "ES3005", "요청한 사진이 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/com/umc/naoman/global/result/code/PhotoResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/PhotoResultCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum PhotoResultCode implements ResultCode {
     CREATE_PRESIGNED_URL(200, "SP000", "성공적으로 Presigned URL을 요청하였습니다."),
     UPLOAD_PHOTO(200, "SP000", "성공적으로 이미지를 업로드하였습니다."),
-    RETRIEVE_PHOTO(200, "SP000", "성공적으로 이미지를 조회하였습니다.")
+    RETRIEVE_PHOTO(200, "SP000", "성공적으로 이미지를 조회하였습니다."),
+    DELETE_PHOTO(200, "SP000", "성공적으로 이미지를 삭제하였습니다.")
 
     ;
     private final int status;


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#40 

## 📝 작업 내용
1. 특정 사진을 삭제하는 API입니다. DB뿐만 아니라 S3 버킷에 저장된 사진도 삭제하도록 구현하였습니다.
2. Presigned URL 발급, 사진 조회, 사진 삭제 작업을 수행하기 전에 특정 그룹에 로그인한 사용자가 포함돼있는지 판단하고 포함되지 있지 않다면 예외를 던지는 로직을 구현하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트