### PR TITLE
[FIX] 회원가입 시 temp-member-info 값 전달 방식 변경 #42

### DIFF
--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -6,23 +6,26 @@ import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
 import com.umc.naoman.domain.member.service.MemberService;
+import com.umc.naoman.global.error.BusinessException;
 import com.umc.naoman.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.umc.naoman.global.error.code.MemberErrorCode.TEMP_MEMBER_INFO_COOKIE_NOT_FOUND;
 import static com.umc.naoman.global.result.code.MemberResultCode.*;
 
 @RestController
@@ -35,12 +38,16 @@ public class AuthController {
     @PostMapping("/signup/web")
     @Operation(summary = "회원가입 API(웹)", description = "웹 클라이언트가 사용하는 회원가입 API입니다.")
     @Parameters(value = {
-            @Parameter(name = "temp-member-info", description = "리다이렉션 시에 쿠키로 넘겨준 사용자 정보가 담긴 jwt를 헤더로 넘겨주세요.",
-                    in = ParameterIn.HEADER)
+            @Parameter(name = "temp-member-info", description = "리다이렉션 시에 쿠키로 넘겨준 사용자 정보가 담긴 jwt가 "
+                    + "요청과 함께 쿠키로 넘어와야 합니다.", in = ParameterIn.COOKIE)
     })
-    public ResultResponse<LoginInfo> signup(@RequestHeader("temp-member-info") String tempMemberInfo,
+    public ResultResponse<LoginInfo> signup(@CookieValue("temp-member-info") Cookie tempMemberInfoCookie,
                                             @Valid @RequestBody MarketingAgreedRequest request) {
-        return ResultResponse.of(SIGNUP, memberService.signup(tempMemberInfo, request));
+        // 추후에 핸들러 처리로 바꿀까 생각 중
+        if (tempMemberInfoCookie == null) {
+            throw new BusinessException(TEMP_MEMBER_INFO_COOKIE_NOT_FOUND);
+        }
+        return ResultResponse.of(SIGNUP, memberService.signup(tempMemberInfoCookie.getValue(), request));
     }
 
     @PostMapping("/signup/android")

--- a/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/MemberErrorCode.java
@@ -13,6 +13,7 @@ public enum MemberErrorCode implements ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(404, "EM000", "해당 refresh token이 존재하지 않습니다."),
     INVALID_SOCIAL_TYPE(404, "EM000", "해당 socialType은 유효하지 않습니다."),
     MEMBER_ALREADY_SIGNUP(400, "EM000", "해당 이메일을 가진 회원은 이미 회원가입하였습니다."),
+    TEMP_MEMBER_INFO_COOKIE_NOT_FOUND(404, "EM000", "회원가입에 사용할 temp-member-info 쿠키가 존재하지 않습니다."),
 
     ;
 


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #42 

## 📝 작업 내용
프론트엔드의 요청에 따라 웹 클라이언트가 회원가입 시, 쿠키로 전달한 `temp-member-info`를 헤더로 변환해 전달 받지 않고, 쿠키 그대로 전달받도록 변경할 예정입니다.
## 💭 주의 사항

## 💡 리뷰 포인트