### PR TITLE
[FEAT] 내 회원정보 조회 구현, 인증되지 않은 사용자의 요청 별도 처리 플로우 구현

### DIFF
--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -2,11 +2,13 @@ package com.umc.naoman.domain.member.controller;
 
 import com.umc.naoman.domain.member.converter.MemberConverter;
 import com.umc.naoman.domain.member.dto.MemberResponse;
+import com.umc.naoman.domain.member.dto.MemberResponse.MemberInfo;
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.service.MemberService;
 import com.umc.naoman.global.error.ErrorResponse;
 import com.umc.naoman.global.result.ResultResponse;
 import com.umc.naoman.global.result.code.MemberResultCode;
+import com.umc.naoman.global.security.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,6 +19,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.umc.naoman.global.result.code.MemberResultCode.CHECK_MEMBER_REGISTRATION;
 
 @RestController
 @RequestMapping("/members")
@@ -36,10 +40,16 @@ public class MemberController {
                     (responseCode = "EM001", description = "해당 memberId를 가진 회원이 존재하지 않습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    public ResultResponse<MemberResponse.MemberInfo> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
+    public ResultResponse<MemberInfo> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
         Member member = memberService.findMember(memberId);
         return ResultResponse.of(MemberResultCode.MEMBER_INFO,
                 memberConverter.toMemberInfo(member));
+    }
+
+    @GetMapping("/my")
+    @Operation(summary = "내 회원정보 조회 API", description = "자신의 회원 정보를 조회하는 API입니다.")
+    public ResultResponse<MemberInfo> checkSignup(@LoginMember Member member) {
+        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, memberService.getMyInfo(member));
     }
 
     @GetMapping("/terms/{memberId}")

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.umc.naoman.domain.member.dto.MemberRequest.MarketingAgreedRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
+import com.umc.naoman.domain.member.dto.MemberResponse.MemberInfo;
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.entity.SocialType;
 
@@ -16,5 +17,5 @@ public interface MemberService {
     LoginInfo signup(SignupRequest request);
     LoginInfo signup(String tempMemberInfo, MarketingAgreedRequest request);
     LoginInfo login(LoginRequest request);
-    // MyPageInfo getMyPageInfo(Member member);
+    MemberInfo getMyInfo(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
@@ -6,6 +6,7 @@ import com.umc.naoman.domain.member.dto.MemberRequest.MarketingAgreedRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
+import com.umc.naoman.domain.member.dto.MemberResponse.MemberInfo;
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.entity.SocialType;
 import com.umc.naoman.domain.member.repository.MemberRepository;
@@ -99,5 +100,10 @@ public class MemberServiceImpl implements MemberService {
         refreshTokenService.saveRefreshToken(memberId, refreshToken);
 
         return memberConverter.toLoginInfo(memberId, accessToken, refreshToken);
+    }
+
+    @Override
+    public MemberInfo getMyInfo(Member member) {
+        return memberConverter.toMemberInfo(member);
     }
 }

--- a/src/main/java/com/umc/naoman/global/error/code/GlobalErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/GlobalErrorCode.java
@@ -22,6 +22,7 @@ public enum GlobalErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(500, "EG051", "내부 서버 오류입니다."),
     UNDEFINED_ERROR(400, "EG100", "정의되지 않은 에러입니다."),
     CLIENT_REGISTRATION_NOT_FOUND(400, "EM000", "해당 registrationId를 가진 ClientRegistration이 존재하지 않습니다."),
+    UNAUTHORIZED(401, "EG000", "인증되지 않은 사용자의 요청입니다. 로그인해 주세요.");
 
     ;
     private final int status;

--- a/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/naoman/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.umc.naoman.domain.member.service.MemberService;
 import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
 import com.umc.naoman.global.security.filter.JwtAuthenticationFilter;
 import com.umc.naoman.global.security.handler.CustomAccessDeniedHandler;
+import com.umc.naoman.global.security.handler.CustomAuthenticationEntryPoint;
 import com.umc.naoman.global.security.handler.OAuth2LoginSuccessHandler;
 import com.umc.naoman.global.security.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
 import com.umc.naoman.global.security.service.CustomOAuth2UserService;
@@ -26,6 +27,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final RefreshTokenService refreshTokenService;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final JwtUtils jwtUtils;
 
     @Bean
@@ -59,14 +61,15 @@ public class SecurityConfig {
                                 "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .exceptionHandling(exception -> exception.accessDeniedHandler(customAccessDeniedHandler))
+                .exceptionHandling(exception -> exception
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                        .authenticationEntryPoint(customAuthenticationEntryPoint))
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(endpoint -> endpoint
                                 .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository()))
                         .userInfoEndpoint(userInfoEndpointConfig ->
                                 userInfoEndpointConfig.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler())
-                        .loginPage("/auth/login")
                 )
                 .addFilterAfter(new JwtAuthenticationFilter(jwtUtils), OAuth2LoginAuthenticationFilter.class);
 

--- a/src/main/java/com/umc/naoman/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.umc.naoman.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.naoman.global.error.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static com.umc.naoman.global.error.code.GlobalErrorCode.UNAUTHORIZED;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(UNAUTHORIZED.getStatus());
+        response.setCharacterEncoding(Charset.defaultCharset().name());
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(response.getStatus())
+                .code(UNAUTHORIZED.getMessage())
+                .message(authException.getMessage())
+                .data(null)
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #59 

## 📝 작업 내용
1. 내 정보를 조회하는 API를 구현하였습니다.
2. 인증되지 않은 사용자의 요청이 올 경우, `/auth/login`로 리다이렉션했지만, 이 대신 적절한 응답을 내뱉는 `CustomAuthenticationEntryPoint`를 구현하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트