### PR TITLE
[FEAT] GPT 프롬프트로 공유그룹 이름 생성, 회원의 프로필 목록 조회 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,18 @@ configurations {
 repositories {
 	mavenCentral()
 	maven { url 'https://jitpack.io' }
+	maven { url 'https://repo.spring.io/milestone' }
+}
+
+ext {
+	set('springAiVersion', "1.0.0-M1")
 }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	// security
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
@@ -36,6 +42,10 @@ dependencies {
 	implementation 'commons-io:commons-io:2.6'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// GPT 프롬프트
+	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+	// implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -64,6 +74,12 @@ dependencies {
 
 	//elasticsearch
 	implementation 'org.springframework.data:spring-data-elasticsearch:'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
@@ -7,7 +7,6 @@ import com.umc.naoman.domain.shareGroup.dto.ShareGroupRequest.createShareGroupRe
 import com.umc.naoman.domain.shareGroup.dto.ShareGroupResponse;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
 import com.umc.naoman.domain.shareGroup.entity.ShareGroup;
-import com.umc.naoman.domain.shareGroup.service.OpenAiService;
 import com.umc.naoman.domain.shareGroup.service.ShareGroupService;
 import com.umc.naoman.global.result.ResultResponse;
 import com.umc.naoman.global.result.code.ShareGroupResultCode;
@@ -57,7 +56,7 @@ public class ShareGroupController {
     })
     public ResultResponse<ShareGroupResponse.ShareGroupDetailInfo> getShareGroupDetailInfo(@PathVariable(name = "shareGroupId") Long shareGroupId) {
         ShareGroup shareGroup = shareGroupService.findShareGroup(shareGroupId);
-        List<Profile> profileList = shareGroupService.findProfileList(shareGroupId);
+        List<Profile> profileList = shareGroupService.findProfileListByShareGroupId(shareGroupId);
 
         return ResultResponse.of(ShareGroupResultCode.SHARE_GROUP_INFO,
                 shareGroupConverter.toShareGroupDetailInfo(shareGroup, profileList));
@@ -70,7 +69,7 @@ public class ShareGroupController {
     })
     public ResultResponse<ShareGroupResponse.ShareGroupDetailInfo> getShareGroupByInviteCode(@RequestParam String inviteCode) {
         ShareGroup shareGroup = shareGroupService.findShareGroup(inviteCode);
-        List<Profile> profileList = shareGroupService.findProfileList(shareGroup.getId());
+        List<Profile> profileList = shareGroupService.findProfileListByShareGroupId(shareGroup.getId());
 
         return ResultResponse.of(ShareGroupResultCode.SHARE_GROUP_INFO,
                 shareGroupConverter.toShareGroupDetailInfo(shareGroup, profileList));

--- a/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
@@ -7,6 +7,7 @@ import com.umc.naoman.domain.shareGroup.dto.ShareGroupRequest.createShareGroupRe
 import com.umc.naoman.domain.shareGroup.dto.ShareGroupResponse;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
 import com.umc.naoman.domain.shareGroup.entity.ShareGroup;
+import com.umc.naoman.domain.shareGroup.service.OpenAiService;
 import com.umc.naoman.domain.shareGroup.service.ShareGroupService;
 import com.umc.naoman.global.result.ResultResponse;
 import com.umc.naoman.global.result.code.ShareGroupResultCode;
@@ -37,12 +38,14 @@ import java.util.List;
 public class ShareGroupController {
     private final ShareGroupService shareGroupService;
     private final ShareGroupConverter shareGroupConverter;
+    private final OpenAiService openAiService;
 
     @PostMapping
     @Operation(summary = "공유그룹 생성 API", description = "새로운 공유그룹을 생성하는 API입니다.")
     public ResultResponse<ShareGroupResponse
             .ShareGroupInfo> createShareGroup(@Valid @RequestBody createShareGroupRequest request,
                                               @LoginMember Member member) {
+        // OpenAI API를 사용하여 그룹 이름 생성
         ShareGroup shareGroup = shareGroupService.createShareGroup(request, member);
         return ResultResponse.of(ShareGroupResultCode.CREATE_SHARE_GROUP, shareGroupConverter.toShareGroupInfo(shareGroup));
     }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
@@ -38,14 +38,12 @@ import java.util.List;
 public class ShareGroupController {
     private final ShareGroupService shareGroupService;
     private final ShareGroupConverter shareGroupConverter;
-    private final OpenAiService openAiService;
 
     @PostMapping
     @Operation(summary = "공유그룹 생성 API", description = "새로운 공유그룹을 생성하는 API입니다.")
     public ResultResponse<ShareGroupResponse
             .ShareGroupInfo> createShareGroup(@Valid @RequestBody createShareGroupRequest request,
                                               @LoginMember Member member) {
-        // OpenAI API를 사용하여 그룹 이름 생성
         ShareGroup shareGroup = shareGroupService.createShareGroup(request, member);
         return ResultResponse.of(ShareGroupResultCode.CREATE_SHARE_GROUP, shareGroupConverter.toShareGroupInfo(shareGroup));
     }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/converter/ShareGroupConverter.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/converter/ShareGroupConverter.java
@@ -18,7 +18,7 @@ public class ShareGroupConverter {
 
     public ShareGroup toEntity(ShareGroupRequest.createShareGroupRequest request, String inviteCode, String groupName) {
         return ShareGroup.builder()
-                .memberCount(request.getMemberNameList().size())  // 변경 가능성 있음. memberCount 대신 nameList의 size 사용
+                .memberCount(request.getMemberNameList().size())  //nameList의 size 사용
                 .inviteCode(inviteCode) // 생성된 초대 코드
                 .name(groupName) // gpt로 만들어진 공유 그룹 이름
                 .build();

--- a/src/main/java/com/umc/naoman/domain/shareGroup/converter/ShareGroupConverter.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/converter/ShareGroupConverter.java
@@ -16,10 +16,11 @@ import java.util.List;
 public class ShareGroupConverter {
     private static final String BASE_URL = "https://naoman/invite/"; //baseUrl 상수
 
-    public ShareGroup toEntity(ShareGroupRequest.createShareGroupRequest request) {
+    public ShareGroup toEntity(ShareGroupRequest.createShareGroupRequest request, String inviteCode, String groupName) {
         return ShareGroup.builder()
                 .memberCount(request.getMemberNameList().size())  // 변경 가능성 있음. memberCount 대신 nameList의 size 사용
-                .name("임시 공유 그룹 이름") //임시 공유 그룹 이름
+                .inviteCode(inviteCode) // 생성된 초대 코드
+                .name(groupName) // gpt로 만들어진 공유 그룹 이름
                 .build();
     }
 

--- a/src/main/java/com/umc/naoman/domain/shareGroup/entity/Profile.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/entity/Profile.java
@@ -1,7 +1,17 @@
 package com.umc.naoman.domain.shareGroup.entity;
 
 import com.umc.naoman.domain.member.entity.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/umc/naoman/domain/shareGroup/entity/ShareGroup.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/entity/ShareGroup.java
@@ -1,11 +1,20 @@
 package com.umc.naoman.domain.shareGroup.entity;
 
 import com.umc.naoman.global.entity.BaseTimeEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/umc/naoman/domain/shareGroup/entity/ShareGroup.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/entity/ShareGroup.java
@@ -13,7 +13,6 @@ import java.util.List;
 @Table(name = "share_groups")
 @SQLRestriction("deleted_at is NULL")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
@@ -1,5 +1,6 @@
 package com.umc.naoman.domain.shareGroup.repository;
 
+import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,5 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByShareGroupIdAndMemberId(Long shareGroupId, Long memberId);
     List<Profile> findByMemberId(Long memberId);
     boolean existsByShareGroupIdAndMemberId(Long shareGroupId, Long memberId);
+    List<Profile> findByMember(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/repository/ProfileRepository.java
@@ -1,6 +1,5 @@
 package com.umc.naoman.domain.shareGroup.repository;
 
-import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,5 +13,4 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByShareGroupIdAndMemberId(Long shareGroupId, Long memberId);
     List<Profile> findByMemberId(Long memberId);
     boolean existsByShareGroupIdAndMemberId(Long shareGroupId, Long memberId);
-    List<Profile> findByMember(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiService.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiService.java
@@ -3,5 +3,5 @@ package com.umc.naoman.domain.shareGroup.service;
 import java.util.List;
 
 public interface OpenAiService {
-    String generateGroupName(String place, List<String> meetingTypes);
+    String generateGroupName(String place, List<String> meetingTypeList);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiService.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiService.java
@@ -1,0 +1,7 @@
+package com.umc.naoman.domain.shareGroup.service;
+
+import java.util.List;
+
+public interface OpenAiService {
+    String generateGroupName(String place, List<String> meetingTypes);
+}

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiServiceImpl.java
@@ -1,0 +1,26 @@
+package com.umc.naoman.domain.shareGroup.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OpenAiServiceImpl implements OpenAiService {
+
+    private final OpenAiChatModel chatModel;
+
+    public String generateGroupName(String place, List<String> meetingTypes) {
+        String prompt = String.format("장소: %s, 모임 종류: %s \n위 키워드를 참고해 재미있는 그룹 이름을 공백 포함 10자~20자 사이로 하나만 지어줘. 큰따옴표는 제외하고 보여줘.", place, String.join(", ", meetingTypes));
+        String response = chatModel.call(prompt);
+        return removeQuotes(response);
+    }
+
+    private String removeQuotes(String response) {
+        return response.replace("\"", ""); // 모든 큰따옴표 제거
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiServiceImpl.java
@@ -14,9 +14,9 @@ public class OpenAiServiceImpl implements OpenAiService {
 
     private final OpenAiChatModel chatModel;
 
-    public String generateGroupName(String place, List<String> meetingTypes) {
+    public String generateGroupName(String place, List<String> meetingTypeList) {
         String prompt = String.format("장소: %s, 모임 종류: %s \n위 키워드를 참고해 재미있는 그룹 이름을 공백 포함 10자~20자 사이로 하나만 지어줘. 큰따옴표는 제외하고 보여줘.",
-                place, String.join(", ", meetingTypes));
+                place, String.join(", ", meetingTypeList));
         String response = chatModel.call(prompt);
         return removeQuotes(response);
     }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/OpenAiServiceImpl.java
@@ -15,7 +15,8 @@ public class OpenAiServiceImpl implements OpenAiService {
     private final OpenAiChatModel chatModel;
 
     public String generateGroupName(String place, List<String> meetingTypes) {
-        String prompt = String.format("장소: %s, 모임 종류: %s \n위 키워드를 참고해 재미있는 그룹 이름을 공백 포함 10자~20자 사이로 하나만 지어줘. 큰따옴표는 제외하고 보여줘.", place, String.join(", ", meetingTypes));
+        String prompt = String.format("장소: %s, 모임 종류: %s \n위 키워드를 참고해 재미있는 그룹 이름을 공백 포함 10자~20자 사이로 하나만 지어줘. 큰따옴표는 제외하고 보여줘.",
+                place, String.join(", ", meetingTypes));
         String response = chatModel.call(prompt);
         return removeQuotes(response);
     }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
@@ -21,4 +21,5 @@ public interface ShareGroupService {
     ShareGroup deleteShareGroup(Long shareGroupId, Member member);
     ShareGroup getInviteInfo(Long shareGroupId, Member member);
     boolean doesProfileExist(Long shareGroupId, Long memberId);
+    List<Profile> findProfileList(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
@@ -11,15 +11,15 @@ import java.util.List;
 
 public interface ShareGroupService {
     ShareGroup createShareGroup(ShareGroupRequest.createShareGroupRequest request, Member member);
+    ShareGroup joinShareGroup(Long shareGroupId, Long profileId, Member member);
+    ShareGroup getInviteInfo(Long shareGroupId, Member member);
+    ShareGroup deleteShareGroup(Long shareGroupId, Member member);
+    Page<ShareGroup> getMyShareGroupList(Member member, Pageable pageable);
     ShareGroup findShareGroup(Long shareGroupId);
     ShareGroup findShareGroup(String inviteCode);
-    List<Profile> findProfileList(Long shareGroupId);
-    ShareGroup joinShareGroup(Long shareGroupId, Long profileId, Member member);
+    List<Profile> findProfileListByShareGroupId(Long shareGroupId);
+    List<Profile> findProfileListByMemberId(Long memberId);
     Profile findProfile(Long profileId);
     Profile findProfile(Long shareGroupId, Long memberID);
-    Page<ShareGroup> getMyShareGroupList(Member member, Pageable pageable);
-    ShareGroup deleteShareGroup(Long shareGroupId, Member member);
-    ShareGroup getInviteInfo(Long shareGroupId, Member member);
     boolean doesProfileExist(Long shareGroupId, Long memberId);
-    List<Profile> findProfileList(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -29,6 +29,7 @@ public class ShareGroupServiceImpl implements ShareGroupService {
     private final ShareGroupRepository shareGroupRepository;
     private final ProfileRepository profileRepository;
     private final ShareGroupConverter shareGroupConverter;
+    private final OpenAiService openAiService;
 
     @Transactional
     @Override
@@ -36,9 +37,13 @@ public class ShareGroupServiceImpl implements ShareGroupService {
         // 초대링크를 위한 고유번호 생성 (UUID)
         String inviteCode = UUID.randomUUID().toString().replace("-", "").toUpperCase();
 
+        // GPT 프롬프트로 groupName 생성
+        String groupName = openAiService.generateGroupName(request.getPlace(), request.getMeetingTypeList());
+
         // 변환 로직
         ShareGroup newShareGroup = shareGroupConverter.toEntity(request);
         newShareGroup.setInviteCode(inviteCode);
+        newShareGroup.setName(groupName);
 
         // 생성된 공유 그룹 저장
         ShareGroup savedShareGroup = shareGroupRepository.save(newShareGroup);

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -142,11 +142,6 @@ public class ShareGroupServiceImpl implements ShareGroupService {
     }
 
     @Override
-    public List<Profile> findProfileList(Long shareGroupId) {
-        return profileRepository.findByShareGroupId(shareGroupId);
-    }
-
-    @Override
     public Profile findProfile(Long profileId) {
         return profileRepository.findById(profileId)
                 .orElseThrow(() -> new BusinessException(ShareGroupErrorCode.PROFILE_NOT_FOUND));
@@ -164,7 +159,12 @@ public class ShareGroupServiceImpl implements ShareGroupService {
     }
 
     @Override
-    public List<Profile> findProfileList(Member member) {
-        return profileRepository.findByMember(member);
+    public List<Profile> findProfileListByShareGroupId(Long shareGroupId) {
+        return profileRepository.findByShareGroupId(shareGroupId);
+    }
+
+    @Override
+    public List<Profile> findProfileListByMemberId(Long memberId) {
+        return profileRepository.findByMemberId(memberId);
     }
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -9,7 +9,6 @@ import com.umc.naoman.domain.shareGroup.entity.ShareGroup;
 import com.umc.naoman.domain.shareGroup.repository.ProfileRepository;
 import com.umc.naoman.domain.shareGroup.repository.ShareGroupRepository;
 import com.umc.naoman.global.error.BusinessException;
-import com.umc.naoman.global.error.code.MemberErrorCode;
 import com.umc.naoman.global.error.code.ShareGroupErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -36,16 +35,14 @@ public class ShareGroupServiceImpl implements ShareGroupService {
     @Override
     public ShareGroup createShareGroup(ShareGroupRequest.createShareGroupRequest request, Member member) {
 
-        // 초대링크를 위한 고유번호 생성 (UUID)
-        String inviteCode = UUID.randomUUID().toString().replace("-", "").toUpperCase();
-
         // GPT 프롬프트로 groupName 생성
         String groupName = openAiService.generateGroupName(request.getPlace(), request.getMeetingTypeList());
 
+        // 초대링크를 위한 고유번호 생성 (UUID)
+        String inviteCode = UUID.randomUUID().toString().replace("-", "").toUpperCase();
+
         // 변환 로직
-        ShareGroup newShareGroup = shareGroupConverter.toEntity(request);
-        newShareGroup.setInviteCode(inviteCode);
-        newShareGroup.setName(groupName);
+        ShareGroup newShareGroup = shareGroupConverter.toEntity(request, inviteCode, groupName);
 
         // 생성된 공유 그룹 저장
         ShareGroup savedShareGroup = shareGroupRepository.save(newShareGroup);

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -163,4 +163,8 @@ public class ShareGroupServiceImpl implements ShareGroupService {
         return profileRepository.existsByShareGroupIdAndMemberId(shareGroupId, memberId);
     }
 
+    @Override
+    public List<Profile> findProfileList(Member member) {
+        return profileRepository.findByMember(member);
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#58

## 📝 작업 내용
openai 라이브러리를 사용해 공유 그룹 생성 API 내부에서, GPT 프롬프트로 공유 그룹 이름을 생성하는 로직을 구현하였습니다.
공백 포함 10자~20자 사이로 만들어지며 따옴표는 출력에서 제외됩니다.

추가로, 회원 탈퇴 시 사용하기 위해 memberId로 프로필 리스트를 조회하는 `List<Profile> findProfileList(Long memberId)` 함수를 구현하였습니다.

## 💭 주의 사항
GPT 프롬프트 사용을 위한 의존성을 주입하였으며, application.yml 또한 업데이트가 필요합니다.
테스트할 때 꼭 meeting type과 place 필드를 유의미하게 작성해 주세요!!!

## 💡 리뷰 포인트