### PR TITLE
[FIX] 회원가입 여부 판별하는 로직 변경, buid.gradle 간소화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,16 +17,17 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+
+	configureEach {
+		exclude group: 'commons-logging', module: 'commons-logging'
+	}
 }
 
 repositories {
 	mavenCentral()
 	maven { url 'https://jitpack.io' }
 	maven { url 'https://repo.spring.io/milestone' }
-}
-
-ext {
-	set('springAiVersion', "1.0.0-M1")
+	maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
@@ -39,13 +40,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
-	implementation 'commons-io:commons-io:2.6'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// GPT 프롬프트
+	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
-	// implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
@@ -61,9 +61,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//firebase
+	// firebase
 	implementation 'com.google.firebase:firebase-admin:8.1.0'
-	//조사 처르를 쉽게 하기 위한 라이브러리
+	// 조사 처르를 쉽게 하기 위한 라이브러리
 	implementation 'com.github.josa-moa:josa-moa:1.0.3'
 
 	// AWS
@@ -72,14 +72,8 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-	//elasticsearch
+	// elasticsearch
 	implementation 'org.springframework.data:spring-data-elasticsearch:'
-}
-
-dependencyManagement {
-	imports {
-		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
-	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -63,11 +63,8 @@ public class AuthController {
     }
 
     @GetMapping("/check-registration")
-    @Operation(summary = "회원가입 여부 조회 API", description = "이메일을 통해, 해당 이메일을 가진 회원의 가입 여부를 조회하는 API입니다.")
-    @Parameters(value = {
-            @Parameter(name = "email", description = "회원가입 여부를 확인할 이메일을 입력해 주세요.")
-    })
-    public ResultResponse<CheckMemberRegistration> checkSignup(@RequestParam("email") @Valid @Email String email) {
-        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, memberService.checkRegistration(email));
+    @Operation(summary = "회원가입 여부 조회 API", description = "authId와 플랫폼명을 통해, 해당 정보와 일치하는 회원의 가입 여부를 조회하는 API입니다.")
+    public ResultResponse<CheckMemberRegistration> checkSignup(@Valid @RequestBody LoginRequest request) {
+        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, memberService.checkRegistration(request));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/naoman/domain/member/repository/MemberRepository.java
@@ -12,4 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByAuthIdAndSocialType(String authId, SocialType socialType);
     Boolean existsByEmail(String email);
+    Boolean existsBySocialTypeAndAuthId(SocialType socialType, String authId);
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
@@ -13,7 +13,7 @@ public interface MemberService {
     Member findMember(Long memberId);
     Member findMember(String email);
     Member findMember(String authId, SocialType socialType);
-    CheckMemberRegistration checkRegistration(String email);
+    CheckMemberRegistration checkRegistration(LoginRequest request);
     LoginInfo signup(SignupRequest request);
     LoginInfo signup(String tempMemberInfo, MarketingAgreedRequest request);
     LoginInfo login(LoginRequest request);

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
@@ -10,12 +10,11 @@ import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.entity.SocialType;
 
 public interface MemberService {
-    Member findMember(Long memberId);
-    Member findMember(String email);
-    Member findMember(String authId, SocialType socialType);
-    CheckMemberRegistration checkRegistration(LoginRequest request);
-    LoginInfo signup(SignupRequest request);
     LoginInfo signup(String tempMemberInfo, MarketingAgreedRequest request);
+    LoginInfo signup(SignupRequest request);
     LoginInfo login(LoginRequest request);
+    CheckMemberRegistration checkRegistration(LoginRequest request);
     MemberInfo getMyInfo(Member member);
+    Member findMember(Long memberId);
+    Member findMember(SocialType socialType, String authId);
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
@@ -35,30 +35,6 @@ public class MemberServiceImpl implements MemberService {
     private Long REFRESH_TOKEN_VALIDITY_IN_SECONDS;
 
     @Override
-    public Member findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_BY_MEMBER_ID));
-    }
-
-    @Override
-    public Member findMember(String email) {
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_BY_EMAIL));
-    }
-
-    @Override
-    public Member findMember(String authId, SocialType socialType) {
-        return memberRepository.findByAuthIdAndSocialType(authId, socialType)
-                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_BY_AUTH_ID_AND_SOCIAL_TYPE));
-    }
-
-    @Override
-    public CheckMemberRegistration checkRegistration(LoginRequest request) {
-        boolean isRegistered = memberRepository.existsBySocialTypeAndAuthId(request.getSocialType(), request.getAuthId());
-        return new CheckMemberRegistration(isRegistered);
-    }
-
-    @Override
     @Transactional
     public LoginInfo signup(SignupRequest request) {
         if (memberRepository.existsByEmail(request.getEmail())) {
@@ -90,7 +66,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public LoginInfo login(LoginRequest request) {
-        Member member = findMember(request.getAuthId(), request.getSocialType());
+        Member member = findMember(request.getSocialType(), request.getAuthId());
 
         Long memberId = member.getId();
         String email = member.getEmail();
@@ -103,7 +79,26 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public CheckMemberRegistration checkRegistration(LoginRequest request) {
+        boolean isRegistered = memberRepository.existsBySocialTypeAndAuthId(request.getSocialType(), request.getAuthId());
+        return new CheckMemberRegistration(isRegistered);
+    }
+
+    @Override
     public MemberInfo getMyInfo(Member member) {
         return memberConverter.toMemberInfo(member);
     }
+
+    @Override
+    public Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_BY_MEMBER_ID));
+    }
+
+    @Override
+    public Member findMember(SocialType socialType, String authId) {
+        return memberRepository.findByAuthIdAndSocialType(authId, socialType)
+                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND_BY_AUTH_ID_AND_SOCIAL_TYPE));
+    }
+
 }

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
@@ -53,8 +53,8 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public CheckMemberRegistration checkRegistration(String email) {
-        boolean isRegistered = memberRepository.existsByEmail(email);
+    public CheckMemberRegistration checkRegistration(LoginRequest request) {
+        boolean isRegistered = memberRepository.existsBySocialTypeAndAuthId(request.getSocialType(), request.getAuthId());
         return new CheckMemberRegistration(isRegistered);
     }
 

--- a/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umc/naoman/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -49,7 +49,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
         try { // 이미 회원가입된 회원인 경우
-            Member member = memberService.findMember(oAuth2User.getEmail());
+            Member member = memberService.findMember(oAuth2User.getProvider(), oAuth2User.getAuthId());
             handleExistingMemberLogin(request, response, oAuth2User, member);
         } catch (BusinessException e) { // 회원가입되어 있지 않은 경우
             handleMemberSignup(request, response, oAuth2User.getOAuthAttribute());

--- a/src/main/java/com/umc/naoman/global/security/model/CustomOAuth2User.java
+++ b/src/main/java/com/umc/naoman/global/security/model/CustomOAuth2User.java
@@ -1,5 +1,6 @@
 package com.umc.naoman.global.security.model;
 
+import com.umc.naoman.domain.member.entity.SocialType;
 import com.umc.naoman.global.security.attribute.OAuthAttribute;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
@@ -20,7 +21,11 @@ public class CustomOAuth2User extends DefaultOAuth2User {
         return oAuthAttribute;
     }
 
-    public String getEmail() {
-        return this.oAuthAttribute.getEmail();
+    public SocialType getProvider() {
+        return this.oAuthAttribute.getProvider();
+    }
+
+    public String getAuthId() {
+        return this.oAuthAttribute.getAuthId();
     }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #66 

## 📝 작업 내용
회원가입 여부를 판별하는 로직이 2가지 있습니다.
-OAuth2LoginSuccessHandler의 onAuthenticationSuccess() 함수
-회원가입 여부 조회 API

이때, 이메일 비교를 통해 확인했는데 동일한 이메일로 여러 소셜플랫폼에 가입하는 경우가 있는 걸 확인하였고, 이메일 대신 authId와 socialType으로 회원가입 여부를 판별하도록 변경하였습니다.
이와 같은 로직 변경으로, `findMember(String email)` 함수의 경우 사용하지 않아 삭제 처리하였습니다.

추가적으로, build.gradle에서 spring AI 프로젝트를 의존하기 위해 사용했던 설정을 Gradle의 native한 support인 `platform` 핸들러 메소드를 통해 간소화하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트