### PR TITLE
[FEAT] 투표하기 및 특정 안건의 투표 현황 조회 API 구현, 자잘한 api 관련 수정

### DIFF
--- a/src/main/java/com/umc/naoman/domain/agenda/controller/AgendaController.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/controller/AgendaController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "04. 안건 관련 API", description = "안건 관련 API입니다.")
 @RequiredArgsConstructor
 @Slf4j
 public class AgendaController {

--- a/src/main/java/com/umc/naoman/domain/agenda/repository/AgendaPhotoRepository.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/repository/AgendaPhotoRepository.java
@@ -4,6 +4,9 @@ import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AgendaPhotoRepository extends JpaRepository<AgendaPhoto, Long> {
+    List<AgendaPhoto> findByAgendaId(Long agendaId);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoService.java
@@ -1,9 +1,13 @@
 package com.umc.naoman.domain.agenda.service;
 
 import com.umc.naoman.domain.agenda.entity.Agenda;
+import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 
 import java.util.List;
 
 public interface AgendaPhotoService {
     void saveAgendaPhotoList(Agenda agenda, List<Long> photos);
+
+    AgendaPhoto findAgendaPhoto(Long agendaPhotoId);
+    List<AgendaPhoto> findAgendaPhotoList(Long agendaId);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoServiceImpl.java
@@ -2,21 +2,25 @@ package com.umc.naoman.domain.agenda.service;
 
 import com.umc.naoman.domain.agenda.converter.AgendaPhotoConverter;
 import com.umc.naoman.domain.agenda.entity.Agenda;
+import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import com.umc.naoman.domain.agenda.repository.AgendaPhotoRepository;
 import com.umc.naoman.domain.photo.entity.Photo;
 import com.umc.naoman.domain.photo.service.PhotoService;
+import com.umc.naoman.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.umc.naoman.global.error.code.AgendaErrorCode.AGENDA_PHOTO_NOT_FOUND;
+
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AgendaPhotoServiceImpl implements AgendaPhotoService {
-
-    private final AgendaPhotoRepository agendaPhotoRepository;
     private final PhotoService photoService;
+    private final AgendaPhotoRepository agendaPhotoRepository;
 
     @Override
     @Transactional
@@ -25,5 +29,16 @@ public class AgendaPhotoServiceImpl implements AgendaPhotoService {
             Photo photo = photoService.findPhoto(photoId);
             agendaPhotoRepository.save(AgendaPhotoConverter.toEntity(agenda, photo));
         }
+    }
+
+    @Override
+    public AgendaPhoto findAgendaPhoto(Long agendaPhotoId) {
+        return agendaPhotoRepository.findById(agendaPhotoId)
+                .orElseThrow(() -> new BusinessException(AGENDA_PHOTO_NOT_FOUND));
+    }
+
+    @Override
+    public List<AgendaPhoto> findAgendaPhotoList(Long agendaId) {
+        return agendaPhotoRepository.findByAgendaId(agendaId);
     }
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaService.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaService.java
@@ -6,8 +6,7 @@ import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import com.umc.naoman.domain.member.entity.Member;
 
 public interface AgendaService {
+    Agenda createAgenda(Member member, AgendaRequest.CreateAgendaRequest request);
 
     Agenda findAgenda(Long agendaId);
-    Agenda createAgenda(Member member, AgendaRequest.CreateAgendaRequest request);
-    AgendaPhoto findAgendaPhoto(Long agendaPhotoId);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaService.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaService.java
@@ -2,10 +2,12 @@ package com.umc.naoman.domain.agenda.service;
 
 import com.umc.naoman.domain.agenda.dto.AgendaRequest;
 import com.umc.naoman.domain.agenda.entity.Agenda;
+import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import com.umc.naoman.domain.member.entity.Member;
 
 public interface AgendaService {
 
     Agenda findAgenda(Long agendaId);
     Agenda createAgenda(Member member, AgendaRequest.CreateAgendaRequest request);
+    AgendaPhoto findAgendaPhoto(Long agendaPhotoId);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
@@ -23,7 +23,6 @@ import static com.umc.naoman.global.error.code.AgendaErrorCode.AGENDA_PHOTO_NOT_
 public class AgendaServiceImpl implements AgendaService {
 
     private final AgendaRepository agendaRepository;
-    private final AgendaPhotoRepository agendaPhotoRepository;
     private final ShareGroupService shareGroupService;
     private final AgendaPhotoService agendaPhotoService;
     private final AgendaConverter agendaConverter;
@@ -45,12 +44,5 @@ public class AgendaServiceImpl implements AgendaService {
         agendaPhotoService.saveAgendaPhotoList(newAgenda,request.getAgendasPhotoList());
 
         return agendaRepository.save(newAgenda);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public AgendaPhoto findAgendaPhoto(Long agendaPhotoId) {
-        return agendaPhotoRepository.findById(agendaPhotoId)
-                .orElseThrow(() -> new BusinessException(AGENDA_PHOTO_NOT_FOUND));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
@@ -3,6 +3,8 @@ package com.umc.naoman.domain.agenda.service;
 import com.umc.naoman.domain.agenda.converter.AgendaConverter;
 import com.umc.naoman.domain.agenda.dto.AgendaRequest;
 import com.umc.naoman.domain.agenda.entity.Agenda;
+import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
+import com.umc.naoman.domain.agenda.repository.AgendaPhotoRepository;
 import com.umc.naoman.domain.agenda.repository.AgendaRepository;
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
@@ -14,11 +16,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.umc.naoman.global.error.code.AgendaErrorCode.AGENDA_PHOTO_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 public class AgendaServiceImpl implements AgendaService {
 
     private final AgendaRepository agendaRepository;
+    private final AgendaPhotoRepository agendaPhotoRepository;
     private final ShareGroupService shareGroupService;
     private final AgendaPhotoService agendaPhotoService;
     private final AgendaConverter agendaConverter;
@@ -40,5 +45,12 @@ public class AgendaServiceImpl implements AgendaService {
         agendaPhotoService.saveAgendaPhotoList(newAgenda,request.getAgendasPhotoList());
 
         return agendaRepository.save(newAgenda);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AgendaPhoto findAgendaPhoto(Long agendaPhotoId) {
+        return agendaPhotoRepository.findById(agendaPhotoId)
+                .orElseThrow(() -> new BusinessException(AGENDA_PHOTO_NOT_FOUND));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.umc.naoman.domain.member.dto.MemberRequest.MarketingAgreedRequest;
 import com.umc.naoman.domain.member.dto.MemberRequest.SignupRequest;
 import com.umc.naoman.domain.member.dto.MemberResponse.CheckMemberRegistration;
 import com.umc.naoman.domain.member.dto.MemberResponse.LoginInfo;
+import com.umc.naoman.domain.member.entity.SocialType;
 import com.umc.naoman.domain.member.service.MemberService;
 import com.umc.naoman.global.error.BusinessException;
 import com.umc.naoman.global.result.ResultResponse;
@@ -64,7 +65,12 @@ public class AuthController {
 
     @GetMapping("/check-registration")
     @Operation(summary = "회원가입 여부 조회 API", description = "authId와 플랫폼명을 통해, 해당 정보와 일치하는 회원의 가입 여부를 조회하는 API입니다.")
-    public ResultResponse<CheckMemberRegistration> checkSignup(@Valid @RequestBody LoginRequest request) {
-        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, memberService.checkRegistration(request));
+    @Parameters(value = {
+            @Parameter(name = "socialType", description = "KAKAO, GOOGLE 중 하나를 입력해야 합니다."),
+            @Parameter(name = "authId", description = "로그인한 소셜 플랫폼에서 제공한 회원 번호를 입력해야 합니다.")
+    })
+    public ResultResponse<CheckMemberRegistration> checkSignup(@RequestParam("socialType") SocialType socialType,
+                                                               @RequestParam("authId") String authId) {
+        return ResultResponse.of(CHECK_MEMBER_REGISTRATION, memberService.checkRegistration(socialType, authId));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/AuthController.java
@@ -30,7 +30,7 @@ import static com.umc.naoman.global.result.code.MemberResultCode.*;
 
 @RestController
 @RequestMapping("/auth")
-@Tag(name = "인증,인가 관련 API", description = "회원의 회원가입 및 로그인 등을 처리하는 API입니다.")
+@Tag(name = "00. 인증,인가 관련 API", description = "회원의 회원가입 및 로그인 등을 처리하는 API입니다.")
 @RequiredArgsConstructor
 public class AuthController {
     private final MemberService memberService;

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -24,7 +24,7 @@ import static com.umc.naoman.global.result.code.MemberResultCode.CHECK_MEMBER_RE
 
 @RestController
 @RequestMapping("/members")
-@Tag(name = "회원 API", description = "회원 도메인의 API입니다.")
+@Tag(name = "01. 회원 API", description = "회원 도메인의 API입니다.")
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberService.java
@@ -13,7 +13,7 @@ public interface MemberService {
     LoginInfo signup(String tempMemberInfo, MarketingAgreedRequest request);
     LoginInfo signup(SignupRequest request);
     LoginInfo login(LoginRequest request);
-    CheckMemberRegistration checkRegistration(LoginRequest request);
+    CheckMemberRegistration checkRegistration(SocialType socialType, String authId);
     MemberInfo getMyInfo(Member member);
     Member findMember(Long memberId);
     Member findMember(SocialType socialType, String authId);

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
@@ -80,8 +80,8 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public CheckMemberRegistration checkRegistration(LoginRequest request) {
-        boolean isRegistered = memberRepository.existsBySocialTypeAndAuthId(request.getSocialType(), request.getAuthId());
+    public CheckMemberRegistration checkRegistration(SocialType socialType, String authId) {
+        boolean isRegistered = memberRepository.existsBySocialTypeAndAuthId(socialType, authId);
         return new CheckMemberRegistration(isRegistered);
     }
 

--- a/src/main/java/com/umc/naoman/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/umc/naoman/domain/notification/controller/NotificationController.java
@@ -11,6 +11,7 @@ import com.umc.naoman.global.result.code.NotificationResultCode;
 import com.umc.naoman.global.security.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,8 +23,9 @@ import java.util.List;
 
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/notifications")
+@Tag(name = "06. 알림 관련 API", description = "나ㅇ만 서비스의 알림 관련 API입니다.")
+@RequiredArgsConstructor
 public class NotificationController {
     private final NotificationService notificationService;
 

--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -37,7 +37,7 @@ import static com.umc.naoman.global.result.code.PhotoResultCode.*;
 @RestController
 @RequestMapping("/photos")
 @RequiredArgsConstructor
-@Tag(name = "사진 관련 API", description = "사진 업로드, 조회, 삭제, 다운로드를 처리하는 API입니다.")
+@Tag(name = "03. 사진 관련 API", description = "사진 업로드, 조회, 삭제, 다운로드를 처리하는 API입니다.")
 public class PhotoController {
 
     private final PhotoService photoService;

--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -9,21 +9,16 @@ import com.umc.naoman.domain.photo.service.PhotoService;
 import com.umc.naoman.global.result.ResultResponse;
 import com.umc.naoman.global.security.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -61,7 +56,9 @@ public class PhotoController {
 
     @GetMapping("/all")
     @Operation(summary = "특정 공유그룹의 전체 사진 조회 API", description = "특정 공유 그룹의 전체 사진을 조회하는 API입니다.")
-    public ResultResponse<PhotoResponse.PagedPhotoInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId, @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+    public ResultResponse<PhotoResponse.PagedPhotoInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId,
+                                                                                    @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                                    @Parameter(hidden = true) Pageable pageable,
                                                                                     @LoginMember Member member) {
         Page<Photo> allPhotoListByShareGroup = photoService.getAllPhotoList(shareGroupId, member, pageable);
         return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPhotoListInfo(allPhotoListByShareGroup));

--- a/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/controller/ShareGroupController.java
@@ -35,7 +35,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/shareGroups")
-@Tag(name = "공유그룹 관련 API", description = "공유그룹 생성, 참여, 조회, 삭제 등을 처리하는 API입니다.")
+@Tag(name = "02. 공유그룹 관련 API", description = "공유그룹 생성, 참여, 조회, 삭제 등을 처리하는 API입니다.")
 public class ShareGroupController {
     private final ShareGroupService shareGroupService;
     private final ShareGroupConverter shareGroupConverter;

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupService.java
@@ -20,6 +20,6 @@ public interface ShareGroupService {
     List<Profile> findProfileListByShareGroupId(Long shareGroupId);
     List<Profile> findProfileListByMemberId(Long memberId);
     Profile findProfile(Long profileId);
-    Profile findProfile(Long shareGroupId, Long memberID);
+    Profile findProfile(Long shareGroupId, Long memberId);
     boolean doesProfileExist(Long shareGroupId, Long memberId);
 }

--- a/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
@@ -2,6 +2,8 @@ package com.umc.naoman.domain.vote.controller;
 
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteListRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse;
+import com.umc.naoman.domain.vote.dto.VoteResponse.AgendaPhotoVoteDetails;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteInfo;
 import com.umc.naoman.domain.vote.service.VoteService;
@@ -18,6 +20,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 import static com.umc.naoman.global.result.code.VoteResultCode.GENERATE_VOTE;
 
@@ -43,10 +47,9 @@ public class VoteController {
     @Parameters(value = {
             @Parameter(name = "agendaId", description = "투표 현황을 조회할 안건의 agendaId를 입력해 주세요.")
     })
-    public ResultResponse<VoteInfo> getVoteList(@PathVariable("agendaId") Long agendaId,
-                                                @LoginMember Member member) {
-//        return ResultResponse.of(GENERATE_VOTE, voteService.getVoteLIst(agendaId, member));
-        return null;
+    public ResultResponse<List<AgendaPhotoVoteDetails>> getVoteList(@PathVariable("agendaId") Long agendaId,
+                                                                    @LoginMember Member member) {
+        return ResultResponse.of(GENERATE_VOTE, voteService.getVoteList(agendaId, member));
     }
 
 }

--- a/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
@@ -1,15 +1,19 @@
 package com.umc.naoman.domain.vote.controller;
 
 import com.umc.naoman.domain.member.entity.Member;
-import com.umc.naoman.domain.vote.dto.VoteRequest;
-import com.umc.naoman.domain.vote.dto.VoteResponse;
-import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteListRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteInfo;
 import com.umc.naoman.domain.vote.service.VoteService;
 import com.umc.naoman.global.result.ResultResponse;
 import com.umc.naoman.global.security.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,16 +22,31 @@ import org.springframework.web.bind.annotation.RestController;
 import static com.umc.naoman.global.result.code.VoteResultCode.GENERATE_VOTE;
 
 @RestController
-@Tag(name = "안건에 대한 투표 관련 API", description = "안건에 대한 투표 행위를 관리하는 API입니다.")
+@Tag(name = "05. 투표 API", description = "안건에 대한 투표 행위를 관리하는 API입니다.")
 @RequiredArgsConstructor
 public class VoteController {
     private final VoteService voteService;
 
     @PostMapping("/agendas/{agendaId}/vote")
-    public ResultResponse<VoteId> generateVote(@PathVariable("agendaId") Long agendaId,
-                                               @Valid @RequestBody VoteRequest.GenerateVoteRequest request,
-                                               @LoginMember Member member) {
-        return ResultResponse.of(GENERATE_VOTE, voteService.generateVote(agendaId, request, member));
+    @Operation(summary = "안건에 투표하기 API", description = "특정 안건에 대하여 투표하는 API입니다. 한 번에 여러 사진에 투표가 가능합니다.")
+    @Parameters(value = {
+            @Parameter(name = "agendaId", description = "투표를 진행할 안건의 agendaId를 입력해 주세요.")
+    })
+    public ResultResponse<VoteIdList> generateVoteList(@PathVariable("agendaId") Long agendaId,
+                                                       @Valid @RequestBody GenerateVoteListRequest request,
+                                                       @LoginMember Member member) {
+        return ResultResponse.of(GENERATE_VOTE, voteService.generateVoteList(agendaId, request, member));
+    }
+
+    @GetMapping("/agendas/{agendaId}/vote")
+    @Operation(summary = "특정 안건의 투표 현황 조회 API", description = "특정 안건에 대한 투표 현항을 조회하는 API입니다.")
+    @Parameters(value = {
+            @Parameter(name = "agendaId", description = "투표 현황을 조회할 안건의 agendaId를 입력해 주세요.")
+    })
+    public ResultResponse<VoteInfo> getVoteList(@PathVariable("agendaId") Long agendaId,
+                                                @LoginMember Member member) {
+//        return ResultResponse.of(GENERATE_VOTE, voteService.getVoteLIst(agendaId, member));
+        return null;
     }
 
 }

--- a/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
@@ -2,10 +2,8 @@ package com.umc.naoman.domain.vote.controller;
 
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteListRequest;
-import com.umc.naoman.domain.vote.dto.VoteResponse;
 import com.umc.naoman.domain.vote.dto.VoteResponse.AgendaPhotoVoteDetails;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
-import com.umc.naoman.domain.vote.dto.VoteResponse.VoteInfo;
 import com.umc.naoman.domain.vote.service.VoteService;
 import com.umc.naoman.global.result.ResultResponse;
 import com.umc.naoman.global.security.annotation.LoginMember;

--- a/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/umc/naoman/domain/vote/controller/VoteController.java
@@ -1,0 +1,33 @@
+package com.umc.naoman.domain.vote.controller;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.vote.dto.VoteRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+import com.umc.naoman.domain.vote.service.VoteService;
+import com.umc.naoman.global.result.ResultResponse;
+import com.umc.naoman.global.security.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.umc.naoman.global.result.code.VoteResultCode.GENERATE_VOTE;
+
+@RestController
+@Tag(name = "안건에 대한 투표 관련 API", description = "안건에 대한 투표 행위를 관리하는 API입니다.")
+@RequiredArgsConstructor
+public class VoteController {
+    private final VoteService voteService;
+
+    @PostMapping("/agendas/{agendaId}/vote")
+    public ResultResponse<VoteId> generateVote(@PathVariable("agendaId") Long agendaId,
+                                               @Valid @RequestBody VoteRequest.GenerateVoteRequest request,
+                                               @LoginMember Member member) {
+        return ResultResponse.of(GENERATE_VOTE, voteService.generateVote(agendaId, request, member));
+    }
+
+}

--- a/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
+++ b/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
@@ -3,7 +3,6 @@ package com.umc.naoman.domain.vote.converter;
 import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import com.umc.naoman.domain.shareGroup.converter.ShareGroupConverter;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
-import com.umc.naoman.domain.vote.dto.VoteResponse;
 import com.umc.naoman.domain.vote.dto.VoteResponse.AgendaPhotoVoteDetails;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;

--- a/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
+++ b/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
@@ -1,0 +1,23 @@
+package com.umc.naoman.domain.vote.converter;
+
+import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
+import com.umc.naoman.domain.shareGroup.entity.Profile;
+import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+import com.umc.naoman.domain.vote.entity.Vote;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VoteConverter {
+    public Vote toEntity(GenerateVoteRequest request, Profile profile, AgendaPhoto agendaPhoto) {
+        return Vote.builder()
+                .comment(request.getComment())
+                .profile(profile)
+                .agendaPhoto(agendaPhoto)
+                .build();
+    }
+
+    public VoteId toVoteId(Long voteId) {
+        return new VoteId(voteId);
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
+++ b/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
@@ -2,19 +2,31 @@ package com.umc.naoman.domain.vote.converter;
 
 import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
-import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
 import com.umc.naoman.domain.vote.entity.Vote;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
 public class VoteConverter {
-    public Vote toEntity(GenerateVoteRequest request, Profile profile, AgendaPhoto agendaPhoto) {
+    public Vote toEntity(String comment, Profile profile, AgendaPhoto agendaPhoto) {
         return Vote.builder()
-                .comment(request.getComment())
+                .comment(comment)
                 .profile(profile)
                 .agendaPhoto(agendaPhoto)
                 .build();
+    }
+
+    public VoteIdList toVoteIdList(List<Vote> voteList) {
+        List<Long> voteIdList = voteList.stream()
+                .map(vote -> vote.getId())
+                .collect(Collectors.toList());
+
+        return new VoteIdList(voteIdList);
     }
 
     public VoteId toVoteId(Long voteId) {

--- a/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
+++ b/src/main/java/com/umc/naoman/domain/vote/converter/VoteConverter.java
@@ -1,24 +1,35 @@
 package com.umc.naoman.domain.vote.converter;
 
 import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
+import com.umc.naoman.domain.shareGroup.converter.ShareGroupConverter;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
 import com.umc.naoman.domain.vote.dto.VoteResponse;
+import com.umc.naoman.domain.vote.dto.VoteResponse.AgendaPhotoVoteDetails;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteInfo;
 import com.umc.naoman.domain.vote.entity.Vote;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class VoteConverter {
+    private final ShareGroupConverter shareGroupConverter;
+
     public Vote toEntity(String comment, Profile profile, AgendaPhoto agendaPhoto) {
         return Vote.builder()
                 .comment(comment)
                 .profile(profile)
                 .agendaPhoto(agendaPhoto)
                 .build();
+    }
+
+    public VoteId toVoteId(Long voteId) {
+        return new VoteId(voteId);
     }
 
     public VoteIdList toVoteIdList(List<Vote> voteList) {
@@ -29,7 +40,26 @@ public class VoteConverter {
         return new VoteIdList(voteIdList);
     }
 
-    public VoteId toVoteId(Long voteId) {
-        return new VoteId(voteId);
+    public VoteInfo toVoteInfo(Vote vote, Profile viewerProfile) {
+        Long voterProfileId = vote.getProfile().getId();
+        Long viewerProfileId = viewerProfile.getId();
+        boolean isMine = voterProfileId.equals(viewerProfileId);
+
+        return VoteInfo.builder()
+                .voteId(vote.getId())
+                .comment(vote.getComment())
+                .profileInfo(shareGroupConverter.toProfileInfo(vote.getProfile()))
+                .agendaPhotoId(vote.getAgendaPhoto().getId())
+                .isMine(isMine)
+                .votedAt(vote.getVotedAt())
+                .build();
+    }
+
+    public AgendaPhotoVoteDetails toAgendaPhotoVoteDetails(Long agendaPhotoId, List<VoteInfo> voteInfoList) {
+        return AgendaPhotoVoteDetails.builder()
+                .agendaPhotoId(agendaPhotoId)
+                .voteInfoList(voteInfoList)
+                .voteCount(voteInfoList.size())
+                .build();
     }
 }

--- a/src/main/java/com/umc/naoman/domain/vote/dto/VoteRequest.java
+++ b/src/main/java/com/umc/naoman/domain/vote/dto/VoteRequest.java
@@ -1,18 +1,31 @@
 package com.umc.naoman.domain.vote.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public abstract class VoteRequest {
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class GenerateVoteListRequest {
+        @NotEmpty(message = "최소 1개의 투표를 한 후 요청해야 합니다.")
+        private List<GenerateVoteRequest> voteInfoList;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class GenerateVoteRequest {
-        // 코멘트 관련 길이 제한
+        @Size(max = 15, message = "투표 코멘트는 최대 15자까지 작성할 수 있습니다.")
         private String comment;
         @NotNull(message = "투표하려는 안건의 사진에 대한 agendaPhotoId 값을 필수로 입력해 주세요.")
         private Long agendaPhotoId;

--- a/src/main/java/com/umc/naoman/domain/vote/dto/VoteRequest.java
+++ b/src/main/java/com/umc/naoman/domain/vote/dto/VoteRequest.java
@@ -1,0 +1,20 @@
+package com.umc.naoman.domain.vote.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public abstract class VoteRequest {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GenerateVoteRequest {
+        // 코멘트 관련 길이 제한
+        private String comment;
+        @NotNull(message = "투표하려는 안건의 사진에 대한 agendaPhotoId 값을 필수로 입력해 주세요.")
+        private Long agendaPhotoId;
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
+++ b/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
@@ -1,0 +1,14 @@
+package com.umc.naoman.domain.vote.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public abstract class VoteResponse {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VoteId {
+        private Long voteId;
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
+++ b/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
@@ -1,7 +1,6 @@
 package com.umc.naoman.domain.vote.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.umc.naoman.domain.shareGroup.dto.ShareGroupResponse;
 import com.umc.naoman.domain.shareGroup.dto.ShareGroupResponse.ProfileInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
+++ b/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
@@ -1,14 +1,42 @@
 package com.umc.naoman.domain.vote.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class VoteResponse {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VoteIdList {
+        @Builder.Default
+        private List<Long> voteIdList = new ArrayList<>();
+    }
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class VoteId {
         private Long voteId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VoteInfo {
+        private Long voteId;
+        private String comment;
+        private Long profileId;
+        private Long agendaPhotoId;
+        @JsonFormat(pattern = "yyy-MM-dd HH:mm:ss")
+        private LocalDateTime votedAt;
     }
 }

--- a/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
+++ b/src/main/java/com/umc/naoman/domain/vote/dto/VoteResponse.java
@@ -1,6 +1,8 @@
 package com.umc.naoman.domain.vote.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.umc.naoman.domain.shareGroup.dto.ShareGroupResponse;
+import com.umc.naoman.domain.shareGroup.dto.ShareGroupResponse.ProfileInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,9 +36,21 @@ public abstract class VoteResponse {
     public static class VoteInfo {
         private Long voteId;
         private String comment;
-        private Long profileId;
+        private ProfileInfo profileInfo;
         private Long agendaPhotoId;
-        @JsonFormat(pattern = "yyy-MM-dd HH:mm:ss")
+        private Boolean isMine;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime votedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AgendaPhotoVoteDetails {
+        private Long agendaPhotoId;
+        @Builder.Default
+        private List<VoteInfo> voteInfoList = new ArrayList<>();
+        private int voteCount;
     }
 }

--- a/src/main/java/com/umc/naoman/domain/vote/entity/Vote.java
+++ b/src/main/java/com/umc/naoman/domain/vote/entity/Vote.java
@@ -1,7 +1,7 @@
 package com.umc.naoman.domain.vote.entity;
 
 import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
-import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.shareGroup.entity.Profile;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -38,8 +38,8 @@ public class Vote {
     private Long id;
     private String comment;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "agendas_photos_id")
     private AgendaPhoto agendaPhoto;

--- a/src/main/java/com/umc/naoman/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/umc/naoman/domain/vote/repository/VoteRepository.java
@@ -1,0 +1,10 @@
+package com.umc.naoman.domain.vote.repository;
+
+import com.umc.naoman.domain.vote.entity.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+    Boolean existsByProfileIdAndAgendaPhotoId(Long profileId, Long agendaPhotoId);
+}

--- a/src/main/java/com/umc/naoman/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/umc/naoman/domain/vote/repository/VoteRepository.java
@@ -4,7 +4,10 @@ import com.umc.naoman.domain.vote.entity.Vote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface VoteRepository extends JpaRepository<Vote, Long> {
     Boolean existsByProfileIdAndAgendaPhotoId(Long profileId, Long agendaPhotoId);
+    List<Vote> findByAgendaPhotoId(Long agendaPhotoId);
 }

--- a/src/main/java/com/umc/naoman/domain/vote/service/VoteService.java
+++ b/src/main/java/com/umc/naoman/domain/vote/service/VoteService.java
@@ -2,8 +2,12 @@ package com.umc.naoman.domain.vote.service;
 
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteListRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse.AgendaPhotoVoteDetails;
 import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
+
+import java.util.List;
 
 public interface VoteService {
     VoteIdList generateVoteList(Long agendaId, GenerateVoteListRequest request, Member member);
+    List<AgendaPhotoVoteDetails> getVoteList(Long agendaId, Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/vote/service/VoteService.java
+++ b/src/main/java/com/umc/naoman/domain/vote/service/VoteService.java
@@ -1,0 +1,9 @@
+package com.umc.naoman.domain.vote.service;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+
+public interface VoteService {
+    VoteId generateVote(Long agendaId, GenerateVoteRequest request, Member member);
+}

--- a/src/main/java/com/umc/naoman/domain/vote/service/VoteService.java
+++ b/src/main/java/com/umc/naoman/domain/vote/service/VoteService.java
@@ -1,9 +1,9 @@
 package com.umc.naoman.domain.vote.service;
 
 import com.umc.naoman.domain.member.entity.Member;
-import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteRequest;
-import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteListRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
 
 public interface VoteService {
-    VoteId generateVote(Long agendaId, GenerateVoteRequest request, Member member);
+    VoteIdList generateVoteList(Long agendaId, GenerateVoteListRequest request, Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/vote/service/VoteServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/vote/service/VoteServiceImpl.java
@@ -1,0 +1,68 @@
+package com.umc.naoman.domain.vote.service;
+
+import com.umc.naoman.domain.agenda.entity.Agenda;
+import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
+import com.umc.naoman.domain.agenda.repository.AgendaPhotoRepository;
+import com.umc.naoman.domain.agenda.service.AgendaService;
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.shareGroup.entity.Profile;
+import com.umc.naoman.domain.shareGroup.service.ShareGroupService;
+import com.umc.naoman.domain.vote.converter.VoteConverter;
+import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteRequest;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+import com.umc.naoman.domain.vote.entity.Vote;
+import com.umc.naoman.domain.vote.repository.VoteRepository;
+import com.umc.naoman.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.umc.naoman.global.error.code.AgendaErrorCode.AGENDA_PHOTO_NOT_FOUND;
+import static com.umc.naoman.global.error.code.VoteErrorCode.DUPLICATE_VOTE;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class VoteServiceImpl implements VoteService {
+    private final ShareGroupService shareGroupService;
+    private final AgendaService agendaService;
+    private final AgendaPhotoRepository agendaPhotoRepository;
+    private final VoteRepository voteRepository;
+    private final VoteConverter voteConverter;
+
+
+    /**
+     * 1. agendaId로 안건을 갖고 온다. (안건의 존재 여부 확인)
+     * 2. 갖고 온 안건에서 shareGroup 객체를 꺼낸다.
+     * 3. shareGroup.findProfile(Long shareGroupId, Long memberId)을 통해 투표를 요청한 사람의 프로필 id를 알아낸다. (프로필 존재 여부 확인)
+     * 4. request.getAgendaPhotoId() 값을 통해 회원이 투표하려고 한 agendaPhoto를 갖고 온다. (agendaPhoto 존재 여부 확인)
+     * 5. 이미 해당 안건의 해당 사진에 투표한 기록이 있는지 확인(중복 투표 방지)
+     * @param agendaId
+     * @param request
+     * @param member
+     * @return
+     */
+    @Override
+    @Transactional
+    public VoteId generateVote(Long agendaId, GenerateVoteRequest request, Member member) {
+        Agenda agenda = agendaService.findAgenda(agendaId);
+        Profile profile = shareGroupService.findProfile(agenda.getShareGroup().getId(), member.getId());
+        // 추후 findAgendaPhoto(Long agendaPhotoId)로 함수화 요청 예정.
+        AgendaPhoto agendaPhoto = agendaPhotoRepository.findById(request.getAgendaPhotoId())
+                .orElseThrow(() -> new BusinessException(AGENDA_PHOTO_NOT_FOUND));
+
+        checkDuplicateVote(profile, agendaPhoto);
+        Vote vote = voteConverter.toEntity(request, profile, agendaPhoto);
+
+        voteRepository.save(vote);
+        return voteConverter.toVoteId(vote.getId());
+    }
+
+    private void checkDuplicateVote(Profile profile, AgendaPhoto agendaPhoto) {
+        if (voteRepository.existsByProfileIdAndAgendaPhotoId(profile.getId(), agendaPhoto.getId())) {
+            throw new BusinessException(DUPLICATE_VOTE);
+        }
+    }
+
+
+}

--- a/src/main/java/com/umc/naoman/domain/vote/service/VoteServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/vote/service/VoteServiceImpl.java
@@ -8,14 +8,18 @@ import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
 import com.umc.naoman.domain.shareGroup.service.ShareGroupService;
 import com.umc.naoman.domain.vote.converter.VoteConverter;
+import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteListRequest;
 import com.umc.naoman.domain.vote.dto.VoteRequest.GenerateVoteRequest;
-import com.umc.naoman.domain.vote.dto.VoteResponse.VoteId;
+import com.umc.naoman.domain.vote.dto.VoteResponse.VoteIdList;
 import com.umc.naoman.domain.vote.entity.Vote;
 import com.umc.naoman.domain.vote.repository.VoteRepository;
 import com.umc.naoman.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.umc.naoman.global.error.code.AgendaErrorCode.AGENDA_PHOTO_NOT_FOUND;
 import static com.umc.naoman.global.error.code.VoteErrorCode.DUPLICATE_VOTE;
@@ -30,39 +34,33 @@ public class VoteServiceImpl implements VoteService {
     private final VoteRepository voteRepository;
     private final VoteConverter voteConverter;
 
-
-    /**
-     * 1. agendaId로 안건을 갖고 온다. (안건의 존재 여부 확인)
-     * 2. 갖고 온 안건에서 shareGroup 객체를 꺼낸다.
-     * 3. shareGroup.findProfile(Long shareGroupId, Long memberId)을 통해 투표를 요청한 사람의 프로필 id를 알아낸다. (프로필 존재 여부 확인)
-     * 4. request.getAgendaPhotoId() 값을 통해 회원이 투표하려고 한 agendaPhoto를 갖고 온다. (agendaPhoto 존재 여부 확인)
-     * 5. 이미 해당 안건의 해당 사진에 투표한 기록이 있는지 확인(중복 투표 방지)
-     * @param agendaId
-     * @param request
-     * @param member
-     * @return
-     */
     @Override
     @Transactional
-    public VoteId generateVote(Long agendaId, GenerateVoteRequest request, Member member) {
-        Agenda agenda = agendaService.findAgenda(agendaId);
+    public VoteIdList generateVoteList(Long agendaId, GenerateVoteListRequest request, Member member) {
+        Agenda agenda = agendaService.findAgenda(agendaId); // 안건의 존재 여부 확인
         Profile profile = shareGroupService.findProfile(agenda.getShareGroup().getId(), member.getId());
-        // 추후 findAgendaPhoto(Long agendaPhotoId)로 함수화 요청 예정.
+
+        List<Vote> voteList = request.getVoteInfoList().stream()
+                .map(voteInfo -> generateVote(voteInfo, profile))
+                .collect(Collectors.toList());
+
+        voteRepository.saveAll(voteList);
+        return voteConverter.toVoteIdList(voteList);
+    }
+
+    private Vote generateVote(GenerateVoteRequest request, Profile profile) {
+        // AgendaPhoto findAgendaPhoto(Long agendaPhotoId)로 함수화 예정
         AgendaPhoto agendaPhoto = agendaPhotoRepository.findById(request.getAgendaPhotoId())
                 .orElseThrow(() -> new BusinessException(AGENDA_PHOTO_NOT_FOUND));
 
         checkDuplicateVote(profile, agendaPhoto);
-        Vote vote = voteConverter.toEntity(request, profile, agendaPhoto);
-
-        voteRepository.save(vote);
-        return voteConverter.toVoteId(vote.getId());
+        return voteConverter.toEntity(request.getComment(), profile, agendaPhoto);
     }
 
+    // 해당 사진에 대한 투표를 이미 했는지 확인한다
     private void checkDuplicateVote(Profile profile, AgendaPhoto agendaPhoto) {
         if (voteRepository.existsByProfileIdAndAgendaPhotoId(profile.getId(), agendaPhoto.getId())) {
             throw new BusinessException(DUPLICATE_VOTE);
         }
     }
-
-
 }

--- a/src/main/java/com/umc/naoman/global/error/code/AgendaErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/AgendaErrorCode.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AgendaErrorCode implements ErrorCode {
     AGENDA_NOT_FOUND_BY_AGENDA_ID(404, "EA001", "해당 agendaId를 가진 안건이 존재하지 않습니다."),
+    AGENDA_PHOTO_NOT_FOUND(404, "EA002", "해당 agendaPhotoId를 가진 안건 후보로 올라간 사진이 존재하지 않습니다."),
+
     ;
 
     private final int status;

--- a/src/main/java/com/umc/naoman/global/error/code/VoteErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/VoteErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.naoman.global.error.code;
+
+import com.umc.naoman.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum VoteErrorCode implements ErrorCode {
+    VOTE_NOT_FOUND(404, "EV001", "해당 voteId를 가진 투표가 존재하지 않습니다."),
+    DUPLICATE_VOTE(400, "EV002", "이미 해당 사진에 투표하였습니다."),
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/MemberResultCode.java
@@ -11,7 +11,7 @@ public enum MemberResultCode implements ResultCode {
     LOGIN(200, "SM000", "성공적으로 로그인하였습니다."),
     MYPAGE_INFO(200, "SM001", "내 정보를 성공적으로 조회하였습니다."),
     EDIT_MYPAGE_INFO(200, "SM002", "내 정보를 성공적으로 수정하였습니다."),
-    CHECK_MEMBER_REGISTRATION(200, "SM000", "해당 이메일을 가진 회원의 가입 여부를 성공적으로 조회하였습니다."),
+    CHECK_MEMBER_REGISTRATION(200, "SM000", "해당 정보에 대응하는 회원의 가입 여부를 성공적으로 조회하였습니다."),
     MEMBER_INFO (200,"SM005","회원 정보를 성공적으로 조회하였습니다."),
     CHECK_MARKETING_AGREED(200,"SM006","마케팅동의여부를 성공적으로 조회하였습니다."),
     ;

--- a/src/main/java/com/umc/naoman/global/result/code/VoteResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/VoteResultCode.java
@@ -1,0 +1,19 @@
+package com.umc.naoman.global.result.code;
+
+import com.umc.naoman.global.result.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum VoteResultCode implements ResultCode {
+    GENERATE_VOTE(200, "SV001", "특정 안건에 대하여 성공적으로 투표하였습니다."),
+    GET_VOTE_LIST(200, "SV002", "특정 안건에 대한 투표 목록을 성공적으로 조회하였습니다."),
+    DELETE_VOTE(200, "SV003", "특정 안건에 대한 투표를 성공적으로 삭제하였습니다."),
+
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #69 

## 📝 작업 내용
- [x] 특정 안건에 투표하기 API 구현 (다중 투표 가능)
- [x] 특정 안건의 투표 현황 조회 API 구현
- [x] 스웨거에 표시되는 도메인별 API의 순서를 설정 (숫자 부여 및 `alphabetical` 형태로 정렬)
- [x] 회원가입 여부 조회 API의 요청 데이터 전달 방식 Request Param으로 변경
- [ ] 공유 그룹의 전체 사진 조회 API의 `pageable` 파라미터가 스웨거에 나타나지 않도록 설정


## 💭 주의 사항
모든 컨트롤러의 `@Tag` 어노테이션의 `name` 속성을 수정했기 때문에 change된 파일들이 많습니다.
## 💡 리뷰 포인트

