### PR TITLE
[FEAT] 샘플 이미지 업로드 API 구현, 이외 사진 도메인 리팩토링

### DIFF
--- a/src/main/java/com/umc/naoman/domain/agenda/repository/AgendaPhotoRepository.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/repository/AgendaPhotoRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface AgendaPhotoRepository extends JpaRepository<AgendaPhoto, Long> {
     List<AgendaPhoto> findByAgendaId(Long agendaId);
+    List<AgendaPhoto> findByPhotoId(Long photoId);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoService.java
@@ -10,4 +10,5 @@ public interface AgendaPhotoService {
 
     AgendaPhoto findAgendaPhoto(Long agendaPhotoId);
     List<AgendaPhoto> findAgendaPhotoList(Long agendaId);
+    List<AgendaPhoto> findAgendaPhotoListByPhotoId(Long photoId);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoServiceImpl.java
@@ -41,4 +41,9 @@ public class AgendaPhotoServiceImpl implements AgendaPhotoService {
     public List<AgendaPhoto> findAgendaPhotoList(Long agendaId) {
         return agendaPhotoRepository.findByAgendaId(agendaId);
     }
+
+    @Override
+    public List<AgendaPhoto> findAgendaPhotoListByPhotoId(Long photoId) {
+        return agendaPhotoRepository.findByPhotoId(photoId);
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaService.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaService.java
@@ -6,6 +6,8 @@ import com.umc.naoman.domain.agenda.entity.Agenda;
 import com.umc.naoman.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface AgendaService {
     Agenda createAgenda(Member member, AgendaRequest.CreateAgendaRequest request);
     Agenda getAgendaDetailInfo(Long agendaId, Member member);
@@ -13,4 +15,5 @@ public interface AgendaService {
     Agenda deleteAgenda(Long agendaId);
 
     Agenda findAgenda(Long agendaId);
+    List<Agenda> findAgendaListByPhotoId(Long photoId);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -75,5 +76,14 @@ public class AgendaServiceImpl implements AgendaService {
 
         agenda.delete();
         return agenda;
+    }
+
+    // 특정 사진이 안건 후보로 담겨 있는 안건 목록을 조회하는 함수
+    @Override
+    public List<Agenda> findAgendaListByPhotoId(Long photoId) {
+        List<AgendaPhoto> agendaPhotoList = agendaPhotoService.findAgendaPhotoListByPhotoId(photoId);
+        return agendaPhotoList.stream()
+                .map(agendaPhoto -> agendaPhoto.getAgenda())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/naoman/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import com.umc.naoman.global.security.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -31,13 +32,11 @@ public class MemberController {
     private final MemberConverter memberConverter;
 
     @GetMapping("/{memberId}") // memberId를 사용해 특정 회원 정보 조회
-    @Operation( summary = "특정 회원 정보 조회 API", description = "[PathVariable]\n memberId\n[request]\n" +
+    @Operation(summary = "특정 회원 정보 조회 API", description = "[PathVariable]\n memberId\n[request]\n" +
             "[response]\n uesrname, email, 소셜 프로필 이미지 url")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse
-                    (responseCode = "SM005", description = "특정 회원 정보 조회 성공."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse
-                    (responseCode = "EM001", description = "해당 memberId를 가진 회원이 존재하지 않습니다.",
+            @ApiResponse(responseCode = "SM005", description = "특정 회원 정보 조회 성공."),
+            @ApiResponse(responseCode = "EM001", description = "해당 memberId를 가진 회원이 존재하지 않습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     public ResultResponse<MemberInfo> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
@@ -55,11 +54,9 @@ public class MemberController {
     @GetMapping("/terms/{memberId}")
     @Operation(summary = "마케팅 약관 동의 여부 조회 API", description = "[PathVariable]\n memberId\n[request]\n" +
             "[response]\n 마케팅 동의 여부 -> 동의 => true, 비동의 => false")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse
-                    (responseCode = "SM006", description = "마케팅 약관 동의 여부 조회 성공."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse
-                    (responseCode = "EM001", description = "해당 memberId를 가진 회원이 존재하지 않습니다.",
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "SM006", description = "마케팅 약관 동의 여부 조회 성공."),
+            @ApiResponse(responseCode = "EM001", description = "해당 memberId를 가진 회원이 존재하지 않습니다.",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
     public ResultResponse<MemberResponse.MarketingAgreed> getMarketingAgreed(@PathVariable(name = "memberId") Long memberId) {

--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -6,7 +6,7 @@ import com.umc.naoman.domain.photo.dto.PhotoRequest.PhotoDeletedRequest;
 import com.umc.naoman.domain.photo.dto.PhotoRequest.PhotoUploadRequest;
 import com.umc.naoman.domain.photo.dto.PhotoRequest.PreSignedUrlRequest;
 import com.umc.naoman.domain.photo.dto.PhotoRequest.UploadSamplePhotoRequest;
-import com.umc.naoman.domain.photo.dto.PhotoResponse.PagedPhotoEsInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PagedPhotoInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDeleteInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDownloadUrlListInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoUploadInfo;
@@ -82,13 +82,13 @@ public class PhotoController {
             @Parameter(name = "page", description = "조회할 페이지를 입력해 주세요.(0번부터 시작)"),
             @Parameter(name = "size", description = "한 페이지에 나타낼 사진 개수를 입력해주세요.")
     })
-    public ResultResponse<PagedPhotoEsInfo> getPhotoListByShareGroupAndProfile(@RequestParam Long shareGroupId,
-                                                                               @RequestParam Long profileId,
-                                                                               @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+    public ResultResponse<PagedPhotoInfo> getPhotoListByShareGroupAndProfile(@RequestParam Long shareGroupId,
+                                                                             @RequestParam Long profileId,
+                                                                             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
                                                                                @Parameter(hidden = true) Pageable pageable,
-                                                                               @LoginMember Member member) {
+                                                                             @LoginMember Member member) {
         Page<PhotoEs> photoEsList = photoEsService.getPhotoEsListByShareGroupIdAndFaceTag(shareGroupId, profileId, member, pageable);
-        return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoEsInfo(photoEsList, member));
+        return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoInfo(photoEsList, member));
     }
 
     @GetMapping("/all")
@@ -98,12 +98,12 @@ public class PhotoController {
             @Parameter(name = "page", description = "조회할 페이지를 입력해 주세요.(0번부터 시작)"),
             @Parameter(name = "size", description = "한 페이지에 나타낼 사진 개수를 입력해주세요.")
     })
-    public ResultResponse<PagedPhotoEsInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId,
-                                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+    public ResultResponse<PagedPhotoInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId,
+                                                                      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
                                                                         @Parameter(hidden = true) Pageable pageable,
-                                                                        @LoginMember Member member) {
+                                                                      @LoginMember Member member) {
         Page<PhotoEs> photoEsList = photoEsService.getAllPhotoEsListByShareGroupId(shareGroupId, member, pageable);
-        return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoEsInfo(photoEsList, member));
+        return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoInfo(photoEsList, member));
     }
 
     @GetMapping("/etc")
@@ -113,12 +113,12 @@ public class PhotoController {
             @Parameter(name = "page", description = "조회할 페이지를 입력해 주세요.(0번부터 시작)"),
             @Parameter(name = "size", description = "한 페이지에 나타낼 사진 개수를 입력해주세요.")
     })
-    public ResultResponse<PagedPhotoEsInfo> getEtcPhotoListByShareGroup(@RequestParam Long shareGroupId,
-                                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+    public ResultResponse<PagedPhotoInfo> getEtcPhotoListByShareGroup(@RequestParam Long shareGroupId,
+                                                                      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
                                                                         @Parameter(hidden = true) Pageable pageable,
-                                                                        @LoginMember Member member) {
+                                                                      @LoginMember Member member) {
         Page<PhotoEs> photoEsList = photoEsService.getEtcPhotoEsListByShareGroupId(shareGroupId, member, pageable);
-        return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoEsInfo(photoEsList, member));
+        return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoInfo(photoEsList, member));
     }
 
     @GetMapping("/download")

--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -2,8 +2,17 @@ package com.umc.naoman.domain.photo.controller;
 
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.photo.converter.PhotoConverter;
-import com.umc.naoman.domain.photo.dto.PhotoRequest;
-import com.umc.naoman.domain.photo.dto.PhotoResponse;
+import com.umc.naoman.domain.photo.dto.PhotoRequest.PhotoDeletedRequest;
+import com.umc.naoman.domain.photo.dto.PhotoRequest.PhotoUploadRequest;
+import com.umc.naoman.domain.photo.dto.PhotoRequest.PreSignedUrlRequest;
+import com.umc.naoman.domain.photo.dto.PhotoRequest.UploadSamplePhotoRequest;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PagedPhotoEsInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDeleteInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDownloadUrlListInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoUploadInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlListInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.SamplePhotoUploadInfo;
 import com.umc.naoman.domain.photo.elasticsearch.document.PhotoEs;
 import com.umc.naoman.domain.photo.elasticsearch.service.PhotoEsService;
 import com.umc.naoman.domain.photo.entity.Photo;
@@ -44,17 +53,24 @@ public class PhotoController {
 
     @PostMapping("/preSignedUrl")
     @Operation(summary = "Presigned URL 요청 API", description = "Presigned URL을 요청하는 API입니다.")
-    public ResultResponse<PhotoResponse.PreSignedUrlListInfo> getPreSignedUrlList(@Valid @RequestBody PhotoRequest.PreSignedUrlRequest request,
-                                                                                  @LoginMember Member member) {
-        List<PhotoResponse.PreSignedUrlInfo> preSignedUrlList = photoService.getPreSignedUrlList(request, member);
+    public ResultResponse<PreSignedUrlListInfo> getPreSignedUrlList(@Valid @RequestBody PreSignedUrlRequest request,
+                                                                    @LoginMember Member member) {
+        List<PreSignedUrlInfo> preSignedUrlList = photoService.getPreSignedUrlList(request, member);
         return ResultResponse.of(CREATE_PRESIGNED_URL, photoConverter.toPreSignedUrlListInfo(preSignedUrlList));
+    }
+
+    @PostMapping("/sample")
+    @Operation(summary = "샘플 사진 업로드 API", description = "얼굴 분류에 사용할 샘플 사진을 업로드하는 API입니다.")
+    public ResultResponse<SamplePhotoUploadInfo> uploadSamplePhotoList(@Valid @RequestBody UploadSamplePhotoRequest request,
+                                                                       @LoginMember Member member) {
+        return ResultResponse.of(UPLOAD_SAMPLE_PHOTO, photoService.uploadSamplePhotoList(request, member));
     }
 
     @PostMapping("/upload")
     @Operation(summary = "사진 업로드 API", description = "Presigned URL을 통해 업로드한 사진을 데이터베이스에 저장하는 API입니다.")
-    public ResultResponse<PhotoResponse.PhotoUploadInfo> uploadPhotoList(@Valid @RequestBody PhotoRequest.PhotoUploadRequest request,
-                                                                         @LoginMember Member member) {
-        PhotoResponse.PhotoUploadInfo photoUploadInfo = photoService.uploadPhotoList(request, member);
+    public ResultResponse<PhotoUploadInfo> uploadPhotoList(@Valid @RequestBody PhotoUploadRequest request,
+                                                           @LoginMember Member member) {
+        PhotoUploadInfo photoUploadInfo = photoService.uploadPhotoList(request, member);
         return ResultResponse.of(UPLOAD_PHOTO, photoUploadInfo);
     }
 
@@ -66,11 +82,11 @@ public class PhotoController {
             @Parameter(name = "page", description = "조회할 페이지를 입력해 주세요.(0번부터 시작)"),
             @Parameter(name = "size", description = "한 페이지에 나타낼 사진 개수를 입력해주세요.")
     })
-    public ResultResponse<PhotoResponse.PagedPhotoEsInfo> getPhotoListByShareGroupAndProfile(@RequestParam Long shareGroupId,
-                                                                                      @RequestParam Long profileId,
-                                                                                      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-                                                                                      @Parameter(hidden = true) Pageable pageable,
-                                                                                      @LoginMember Member member) {
+    public ResultResponse<PagedPhotoEsInfo> getPhotoListByShareGroupAndProfile(@RequestParam Long shareGroupId,
+                                                                               @RequestParam Long profileId,
+                                                                               @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                               @Parameter(hidden = true) Pageable pageable,
+                                                                               @LoginMember Member member) {
         Page<PhotoEs> photoEsList = photoEsService.getPhotoEsListByShareGroupIdAndFaceTag(shareGroupId, profileId, member, pageable);
         return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoEsInfo(photoEsList, member));
     }
@@ -82,10 +98,10 @@ public class PhotoController {
             @Parameter(name = "page", description = "조회할 페이지를 입력해 주세요.(0번부터 시작)"),
             @Parameter(name = "size", description = "한 페이지에 나타낼 사진 개수를 입력해주세요.")
     })
-    public ResultResponse<PhotoResponse.PagedPhotoEsInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId,
-                                                                                      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-                                                                                      @Parameter(hidden = true) Pageable pageable,
-                                                                                      @LoginMember Member member) {
+    public ResultResponse<PagedPhotoEsInfo> getAllPhotoListByShareGroup(@RequestParam Long shareGroupId,
+                                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                        @Parameter(hidden = true) Pageable pageable,
+                                                                        @LoginMember Member member) {
         Page<PhotoEs> photoEsList = photoEsService.getAllPhotoEsListByShareGroupId(shareGroupId, member, pageable);
         return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoEsInfo(photoEsList, member));
     }
@@ -97,27 +113,28 @@ public class PhotoController {
             @Parameter(name = "page", description = "조회할 페이지를 입력해 주세요.(0번부터 시작)"),
             @Parameter(name = "size", description = "한 페이지에 나타낼 사진 개수를 입력해주세요.")
     })
-    public ResultResponse<PhotoResponse.PagedPhotoEsInfo> getEtcPhotoListByShareGroup(@RequestParam Long shareGroupId,
-                                                                            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-                                                                            @Parameter(hidden = true) Pageable pageable,
-                                                                            @LoginMember Member member) {
+    public ResultResponse<PagedPhotoEsInfo> getEtcPhotoListByShareGroup(@RequestParam Long shareGroupId,
+                                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                                        @Parameter(hidden = true) Pageable pageable,
+                                                                        @LoginMember Member member) {
         Page<PhotoEs> photoEsList = photoEsService.getEtcPhotoEsListByShareGroupId(shareGroupId, member, pageable);
         return ResultResponse.of(RETRIEVE_PHOTO, photoConverter.toPagedPhotoEsInfo(photoEsList, member));
     }
 
-    @DeleteMapping
-    @Operation(summary = "사진 삭제 API", description = "사진을 삭제하는 API입니다. 해당 공유그룹에 속해있는 회원만 삭제할 수 있습니다.")
-    public ResultResponse<PhotoResponse.PhotoDeleteInfo> deletePhotoList(@Valid @RequestBody PhotoRequest.PhotoDeletedRequest request,
-                                                                         @LoginMember Member member) {
-        List<Photo> photoList = photoService.deletePhotoList(request, member);
-        return ResultResponse.of(DELETE_PHOTO, photoConverter.toPhotoDeleteInfo(photoList));
-    }
-
     @GetMapping("/download")
     @Operation(summary = "사진 다운로드 API", description = "여러장의 사진을 다운로드할 주소를 받는  API입니다. 해당 공유그룹에 속해있는 회원만 다운로드 요청할 수 있습니다.")
-    public ResultResponse<PhotoResponse.PhotoDownloadUrlListInfo> getPhotoDownloadUrlList(@RequestParam List<Long> photoIdList, @RequestParam Long shareGroupId,
-                                                                                          @LoginMember Member member) {
-        PhotoResponse.PhotoDownloadUrlListInfo photoDownloadUrlList = photoService.getPhotoDownloadUrlList(photoIdList, shareGroupId, member);
+    public ResultResponse<PhotoDownloadUrlListInfo> getPhotoDownloadUrlList(@RequestParam List<Long> photoIdList,
+                                                                            @RequestParam Long shareGroupId,
+                                                                            @LoginMember Member member) {
+        PhotoDownloadUrlListInfo photoDownloadUrlList = photoService.getPhotoDownloadUrlList(photoIdList, shareGroupId, member);
         return ResultResponse.of(DOWNLOAD_PHOTO, photoDownloadUrlList);
+    }
+
+    @DeleteMapping
+    @Operation(summary = "사진 삭제 API", description = "사진을 삭제하는 API입니다. 해당 공유그룹에 속해있는 회원만 삭제할 수 있습니다.")
+    public ResultResponse<PhotoDeleteInfo> deletePhotoList(@Valid @RequestBody PhotoDeletedRequest request,
+                                                           @LoginMember Member member) {
+        List<Photo> photoList = photoService.deletePhotoList(request, member);
+        return ResultResponse.of(DELETE_PHOTO, photoConverter.toPhotoDeleteInfo(photoList));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
+++ b/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
@@ -1,10 +1,10 @@
 package com.umc.naoman.domain.photo.converter;
 
 import com.umc.naoman.domain.member.entity.Member;
-import com.umc.naoman.domain.photo.dto.PhotoResponse.PagedPhotoEsInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PagedPhotoInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDeleteInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDownloadUrlListInfo;
-import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoEsInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoUploadInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlListInfo;
@@ -68,27 +68,27 @@ public class PhotoConverter {
                 .build();
     }
 
-    public PagedPhotoEsInfo toPagedPhotoEsInfo(Page<PhotoEs> photoEsList, Member member) {
-        List<PhotoEsInfo> photoEsInfoList = photoEsList.stream()
-                .map(photoEs -> toPhotoEsInfo(photoEs, member))
+    public PagedPhotoInfo toPagedPhotoInfo(Page<PhotoEs> photoEsList, Member member) {
+        List<PhotoInfo> photoInfoList = photoEsList.stream()
+                .map(photoEs -> toPhotoInfo(photoEs, member))
                 .collect(Collectors.toList());
 
-        return PagedPhotoEsInfo.builder()
+        return PagedPhotoInfo.builder()
                 .isLast(photoEsList.isLast())
                 .isFirst(photoEsList.isFirst())
                 .totalPages(photoEsList.getTotalPages())
                 .totalElements(photoEsList.getTotalElements())
-                .photoEsInfoList(photoEsInfoList)
+                .photoInfoList(photoInfoList)
                 .build();
     }
 
-    public PhotoEsInfo toPhotoEsInfo(PhotoEs photoEs, Member member) {
+    public PhotoInfo toPhotoInfo(PhotoEs photoEs, Member member) {
         String rawUrl = photoEs.getUrl();
         Boolean isDownload = !photoEs.getDownloadTag().isEmpty() && photoEs.getDownloadTag().contains(member.getId());
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         LocalDateTime createdAt = LocalDateTime.parse(photoEs.getCreatedAt(), dateTimeFormatter);
 
-        return PhotoEsInfo.builder()
+        return PhotoInfo.builder()
                 .photoId(photoEs.getRdsId())
                 .rawPhotoUrl(rawUrl)
                 .w200PhotoUrl(createResizedPhotoUrl(rawUrl, W200_PATH_PREFIX))

--- a/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
+++ b/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
@@ -1,7 +1,14 @@
 package com.umc.naoman.domain.photo.converter;
 
 import com.umc.naoman.domain.member.entity.Member;
-import com.umc.naoman.domain.photo.dto.PhotoResponse;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PagedPhotoEsInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDeleteInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDownloadUrlListInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoEsInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoUploadInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlListInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.SamplePhotoUploadInfo;
 import com.umc.naoman.domain.photo.elasticsearch.document.PhotoEs;
 import com.umc.naoman.domain.photo.entity.Photo;
 import com.umc.naoman.domain.shareGroup.entity.ShareGroup;
@@ -17,29 +24,6 @@ import static com.umc.naoman.domain.photo.service.PhotoServiceImpl.*;
 
 @Component
 public class PhotoConverter {
-
-    public PhotoResponse.PreSignedUrlListInfo toPreSignedUrlListInfo(List<PhotoResponse.PreSignedUrlInfo> preSignedUrlList) {
-        List<PhotoResponse.PreSignedUrlInfo> preSignedUrlInfoList = preSignedUrlList.stream()
-                .map(preSignedUrlInfo -> toPreSignedUrlInfo(
-                        preSignedUrlInfo.getPreSignedUrl(),
-                        preSignedUrlInfo.getPhotoUrl(),
-                        preSignedUrlInfo.getPhotoName()
-                ))
-                .collect(Collectors.toList());
-
-        return PhotoResponse.PreSignedUrlListInfo.builder()
-                .preSignedUrlInfoList(preSignedUrlInfoList)
-                .build();
-    }
-
-    public PhotoResponse.PreSignedUrlInfo toPreSignedUrlInfo(String preSignedUrl, String photoUrl, String photoName) {
-        return PhotoResponse.PreSignedUrlInfo.builder()
-                .preSignedUrl(preSignedUrl)
-                .photoUrl(photoUrl)
-                .photoName(photoName)
-                .build();
-    }
-
     public Photo toEntity(String photoUrl, String photoName, ShareGroup shareGroup) {
         return Photo.builder()
                 .url(photoUrl)
@@ -48,12 +32,48 @@ public class PhotoConverter {
                 .build();
     }
 
-    public PhotoResponse.PagedPhotoEsInfo toPagedPhotoEsInfo(Page<PhotoEs> photoEsList, Member member) {
-        List<PhotoResponse.PhotoEsInfo> photoEsInfoList = photoEsList.stream()
+    public PreSignedUrlListInfo toPreSignedUrlListInfo(List<PreSignedUrlInfo> preSignedUrlList) {
+        List<PreSignedUrlInfo> preSignedUrlInfoList = preSignedUrlList.stream()
+                .map(preSignedUrlInfo -> toPreSignedUrlInfo(
+                        preSignedUrlInfo.getPreSignedUrl(),
+                        preSignedUrlInfo.getPhotoUrl(),
+                        preSignedUrlInfo.getPhotoName()
+                ))
+                .collect(Collectors.toList());
+
+        return PreSignedUrlListInfo.builder()
+                .preSignedUrlInfoList(preSignedUrlInfoList)
+                .build();
+    }
+
+    public PreSignedUrlInfo toPreSignedUrlInfo(String preSignedUrl, String photoUrl, String photoName) {
+        return PreSignedUrlInfo.builder()
+                .preSignedUrl(preSignedUrl)
+                .photoUrl(photoUrl)
+                .photoName(photoName)
+                .build();
+    }
+
+    public SamplePhotoUploadInfo toSamplePhotoUploadInfo(Long memberId, int uploadCount) {
+        return SamplePhotoUploadInfo.builder()
+                .memberId(memberId)
+                .uploadCount(uploadCount)
+                .build();
+    }
+
+    public PhotoUploadInfo toPhotoUploadInfo(Long shareGroupId, int uploadCount) {
+        return PhotoUploadInfo.builder()
+                .shareGroupId(shareGroupId)
+                .uploadCount(uploadCount)
+                .build();
+    }
+
+    public PagedPhotoEsInfo toPagedPhotoEsInfo(Page<PhotoEs> photoEsList, Member member) {
+        List<PhotoEsInfo> photoEsInfoList = photoEsList.stream()
                 .map(photoEs -> toPhotoEsInfo(photoEs, member))
                 .collect(Collectors.toList());
 
-        return PhotoResponse.PagedPhotoEsInfo.builder()
+        return PagedPhotoEsInfo.builder()
                 .isLast(photoEsList.isLast())
                 .isFirst(photoEsList.isFirst())
                 .totalPages(photoEsList.getTotalPages())
@@ -62,13 +82,13 @@ public class PhotoConverter {
                 .build();
     }
 
-    public PhotoResponse.PhotoEsInfo toPhotoEsInfo(PhotoEs photoEs, Member member) {
+    public PhotoEsInfo toPhotoEsInfo(PhotoEs photoEs, Member member) {
         String rawUrl = photoEs.getUrl();
         Boolean isDownload = !photoEs.getDownloadTag().isEmpty() && photoEs.getDownloadTag().contains(member.getId());
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         LocalDateTime createdAt = LocalDateTime.parse(photoEs.getCreatedAt(), dateTimeFormatter);
 
-        return PhotoResponse.PhotoEsInfo.builder()
+        return PhotoEsInfo.builder()
                 .photoId(photoEs.getRdsId())
                 .rawPhotoUrl(rawUrl)
                 .w200PhotoUrl(createResizedPhotoUrl(rawUrl, W200_PATH_PREFIX))
@@ -93,22 +113,22 @@ public class PhotoConverter {
         return photoUrl.replace(".HEIC", ".jpg");
     }
 
-    public PhotoResponse.PhotoDeleteInfo toPhotoDeleteInfo(List<Photo> photoList) {
+    public PhotoDeleteInfo toPhotoDeleteInfo(List<Photo> photoList) {
         List<Long> photoIdList = photoList.stream()
                 .map(Photo::getId)
                 .collect(Collectors.toList());
 
-        return PhotoResponse.PhotoDeleteInfo.builder()
+        return PhotoDeleteInfo.builder()
                 .photoIdList(photoIdList)
                 .build();
     }
 
-    public PhotoResponse.PhotoDownloadUrlListInfo toPhotoDownloadUrlListInfo(List<Photo> photoList) {
+    public PhotoDownloadUrlListInfo toPhotoDownloadUrlListInfo(List<Photo> photoList) {
         List<String> photoDownloadUrlList = photoList.stream()
                 .map(Photo::getUrl)
                 .collect(Collectors.toList());
 
-        return PhotoResponse.PhotoDownloadUrlListInfo.builder()
+        return PhotoDownloadUrlListInfo.builder()
                 .photoDownloadUrlList(photoDownloadUrlList)
                 .build();
     }

--- a/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
+++ b/src/main/java/com/umc/naoman/domain/photo/converter/PhotoConverter.java
@@ -54,13 +54,6 @@ public class PhotoConverter {
                 .build();
     }
 
-    public SamplePhotoUploadInfo toSamplePhotoUploadInfo(Long memberId, int uploadCount) {
-        return SamplePhotoUploadInfo.builder()
-                .memberId(memberId)
-                .uploadCount(uploadCount)
-                .build();
-    }
-
     public PhotoUploadInfo toPhotoUploadInfo(Long shareGroupId, int uploadCount) {
         return PhotoUploadInfo.builder()
                 .shareGroupId(shareGroupId)

--- a/src/main/java/com/umc/naoman/domain/photo/converter/SamplePhotoConverter.java
+++ b/src/main/java/com/umc/naoman/domain/photo/converter/SamplePhotoConverter.java
@@ -1,6 +1,7 @@
 package com.umc.naoman.domain.photo.converter;
 
 import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.photo.dto.PhotoResponse;
 import com.umc.naoman.domain.photo.entity.SamplePhoto;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,13 @@ public class SamplePhotoConverter {
                 .url(photoUrl)
                 .name(photoName)
                 .member(member)
+                .build();
+    }
+
+    public PhotoResponse.SamplePhotoUploadInfo toSamplePhotoUploadInfo(Long memberId, int uploadCount) {
+        return PhotoResponse.SamplePhotoUploadInfo.builder()
+                .memberId(memberId)
+                .uploadCount(uploadCount)
                 .build();
     }
 }

--- a/src/main/java/com/umc/naoman/domain/photo/converter/SamplePhotoConverter.java
+++ b/src/main/java/com/umc/naoman/domain/photo/converter/SamplePhotoConverter.java
@@ -1,0 +1,16 @@
+package com.umc.naoman.domain.photo.converter;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.photo.entity.SamplePhoto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SamplePhotoConverter {
+    public SamplePhoto toEntity(String photoUrl, String photoName, Member member) {
+        return SamplePhoto.builder()
+                .url(photoUrl)
+                .name(photoName)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/photo/dto/PhotoRequest.java
+++ b/src/main/java/com/umc/naoman/domain/photo/dto/PhotoRequest.java
@@ -2,6 +2,7 @@ package com.umc.naoman.domain.photo.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +23,15 @@ public abstract class PhotoRequest {
         @NotEmpty(message = "사진의 이름은 하나 이상이어야 합니다.")
         private List<String> photoNameList;
 
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UploadSamplePhotoRequest {
+        @Size(min = 2, message = "샘플 사진의 개수는 최소 2개 이상이어야 합니다.")
+        private List<String> photoUrlList;
     }
 
     @Getter

--- a/src/main/java/com/umc/naoman/domain/photo/dto/PhotoResponse.java
+++ b/src/main/java/com/umc/naoman/domain/photo/dto/PhotoResponse.java
@@ -51,8 +51,8 @@ public abstract class PhotoResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PagedPhotoEsInfo {
-        private List<PhotoEsInfo> photoEsInfoList;
+    public static class PagedPhotoInfo {
+        private List<PhotoInfo> photoInfoList;
         private Integer totalPages;
         private Long totalElements;
         private Boolean isFirst;
@@ -63,7 +63,7 @@ public abstract class PhotoResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class PhotoEsInfo {
+    public static class PhotoInfo {
         private Long photoId;
         private String rawPhotoUrl;
         private String w200PhotoUrl;

--- a/src/main/java/com/umc/naoman/domain/photo/dto/PhotoResponse.java
+++ b/src/main/java/com/umc/naoman/domain/photo/dto/PhotoResponse.java
@@ -42,6 +42,15 @@ public abstract class PhotoResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class SamplePhotoUploadInfo {
+        private Long memberId;
+        private int uploadCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class PagedPhotoEsInfo {
         private List<PhotoEsInfo> photoEsInfoList;
         private Integer totalPages;

--- a/src/main/java/com/umc/naoman/domain/photo/repository/SamplePhotoRepository.java
+++ b/src/main/java/com/umc/naoman/domain/photo/repository/SamplePhotoRepository.java
@@ -1,0 +1,9 @@
+package com.umc.naoman.domain.photo.repository;
+
+import com.umc.naoman.domain.photo.entity.SamplePhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SamplePhotoRepository extends JpaRepository<SamplePhoto, Long> {
+}

--- a/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionService.java
@@ -6,4 +6,5 @@ public interface FaceDetectionService {
 
     void detectFaceUploadPhoto(List<String> photoNameList, Long shareGroupId, List<Long> memberIdList);
     void detectFaceJoinShareGroup(Long memberId, Long shareGroupId);
+    void detectFaceSamplePhoto(Long memberId, List<String> photoNameList);
 }

--- a/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionService.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public interface FaceDetectionService {
 
-    void detectFaceUploadPhoto(List<String> photoNameList, Long shareGroupId);
+    void detectFaceUploadPhoto(List<String> photoNameList, Long shareGroupId, List<Long> memberIdList);
     void detectFaceJoinShareGroup(Long memberId, Long shareGroupId);
 }

--- a/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionServiceImpl.java
@@ -1,18 +1,19 @@
 package com.umc.naoman.domain.photo.service;
+
 import com.amazonaws.services.lambda.AWSLambda;
 import com.amazonaws.services.lambda.model.InvocationType;
 import com.amazonaws.services.lambda.model.InvokeRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.naoman.domain.shareGroup.service.ShareGroupService;
 import com.umc.naoman.global.error.BusinessException;
 import com.umc.naoman.global.error.code.AwsLambdaErrorCode;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +24,6 @@ public class FaceDetectionServiceImpl implements FaceDetectionService {
     private String detectFaceJoinShareGroupLambda;
     private final AWSLambda awsLambda;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final ShareGroupService shareGroupService;
 
     @Getter
     @AllArgsConstructor
@@ -41,10 +41,7 @@ public class FaceDetectionServiceImpl implements FaceDetectionService {
     }
 
     @Override
-    public void detectFaceUploadPhoto(List<String> photoNameList, Long shareGroupId) {
-        List<Long> memberIdList = shareGroupService.findProfileListByShareGroupId(shareGroupId).stream()
-                .map(profile -> profile.getMember().getId())
-                .collect(Collectors.toList());
+    public void detectFaceUploadPhoto(List<String> photoNameList, Long shareGroupId, List<Long> memberIdList) {
         DetectFacePhotoPayload payLoad = new DetectFacePhotoPayload(photoNameList, memberIdList, shareGroupId);
         String lambdaPayload = null;
 

--- a/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/FaceDetectionServiceImpl.java
@@ -22,6 +22,8 @@ public class FaceDetectionServiceImpl implements FaceDetectionService {
     private String detectFaceUploadPhotoLambda;
     @Value("${spring.lambda.function.detect_face_join_share_group}")
     private String detectFaceJoinShareGroupLambda;
+    @Value("${spring.lambda.function.detect_face_sample_photo}")
+    private String detectFaceSamplePhotoLambda;
     private final AWSLambda awsLambda;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -38,6 +40,13 @@ public class FaceDetectionServiceImpl implements FaceDetectionService {
     private class DetectFaceShareGroupPayload {
         private Long memberId;
         private Long shareGroupId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private class DetectFaceSamplePhotoPayload {
+        private long memberId;
+        private List<String> photoNameList;
     }
 
     @Override
@@ -71,6 +80,23 @@ public class FaceDetectionServiceImpl implements FaceDetectionService {
         InvokeRequest invokeRequest = new InvokeRequest()
                 .withInvocationType(InvocationType.Event) //비동기 호출
                 .withFunctionName(detectFaceJoinShareGroupLambda)
+                .withPayload(lambdaPayload);
+
+        awsLambda.invoke(invokeRequest);
+    }
+
+    @Override
+    public void detectFaceSamplePhoto(Long memberId, List<String> photoNameList) {
+        DetectFaceSamplePhotoPayload photoPayload = new DetectFaceSamplePhotoPayload(memberId,photoNameList);
+        String lambdaPayload = null;
+        try{
+            lambdaPayload = objectMapper.writeValueAsString(photoPayload);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(AwsLambdaErrorCode.AWS_JsonProcessing_Exception, e);
+        }
+        InvokeRequest invokeRequest = new InvokeRequest()
+                .withInvocationType(InvocationType.Event) //비동기 호출
+                .withFunctionName(detectFaceSamplePhotoLambda)
                 .withPayload(lambdaPayload);
 
         awsLambda.invoke(invokeRequest);

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -2,15 +2,21 @@ package com.umc.naoman.domain.photo.service;
 
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.photo.dto.PhotoRequest;
-import com.umc.naoman.domain.photo.dto.PhotoResponse;
+import com.umc.naoman.domain.photo.dto.PhotoRequest.UploadSamplePhotoRequest;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDownloadUrlListInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoUploadInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.SamplePhotoUploadInfo;
 import com.umc.naoman.domain.photo.entity.Photo;
 
 import java.util.List;
 
 public interface PhotoService {
-    List<PhotoResponse.PreSignedUrlInfo> getPreSignedUrlList(PhotoRequest.PreSignedUrlRequest request, Member member);
-    PhotoResponse.PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request, Member member);
+    List<PreSignedUrlInfo> getPreSignedUrlList(PhotoRequest.PreSignedUrlRequest request, Member member);
+    SamplePhotoUploadInfo uploadSamplePhotoList(UploadSamplePhotoRequest request, Member member);
+    PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request, Member member);
+    PhotoDownloadUrlListInfo getPhotoDownloadUrlList(List<Long> photoIdList, Long shareGroupId, Member member);
     List<Photo> deletePhotoList(PhotoRequest.PhotoDeletedRequest request, Member member);
+
     Photo findPhoto(Long photoId);
-    PhotoResponse.PhotoDownloadUrlListInfo getPhotoDownloadUrlList(List<Long> photoIdList, Long shareGroupId, Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -130,7 +130,7 @@ public class PhotoServiceImpl implements PhotoService {
         // =================경호님이 작업하실 라인================
         // dummyFunction(samplePhotoNameList, member.getId());
 
-        return photoConverter.toSamplePhotoUploadInfo(member.getId(), samplePhotoList.size());
+        return samplePhotoConverter.toSamplePhotoUploadInfo(member.getId(), samplePhotoList.size());
     }
 
     private SamplePhoto checkAndSaveSamplePhotoInDB(String photoUrl, String photoName, Member member) {

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -27,7 +27,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.umc.naoman.global.error.code.S3ErrorCode.*;
+import static com.umc.naoman.global.error.code.S3ErrorCode.PHOTO_NOT_FOUND;
+import static com.umc.naoman.global.error.code.S3ErrorCode.PHOTO_NOT_FOUND_S3;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -127,8 +127,7 @@ public class PhotoServiceImpl implements PhotoService {
                 .toList();
 
         // Elasticsearch에 sample_face_vector를 저장하기 위한 트리거 실행
-        // =================경호님이 작업하실 라인================
-        // dummyFunction(samplePhotoNameList, member.getId());
+        faceDetectionService.detectFaceSamplePhoto(member.getId(), samplePhotoNameList);
 
         return samplePhotoConverter.toSamplePhotoUploadInfo(member.getId(), samplePhotoList.size());
     }

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -7,11 +7,19 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.photo.converter.PhotoConverter;
+import com.umc.naoman.domain.photo.converter.SamplePhotoConverter;
 import com.umc.naoman.domain.photo.dto.PhotoRequest;
-import com.umc.naoman.domain.photo.dto.PhotoResponse;
+import com.umc.naoman.domain.photo.dto.PhotoRequest.PhotoUploadRequest;
+import com.umc.naoman.domain.photo.dto.PhotoRequest.UploadSamplePhotoRequest;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoDownloadUrlListInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PhotoUploadInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlInfo;
+import com.umc.naoman.domain.photo.dto.PhotoResponse.SamplePhotoUploadInfo;
 import com.umc.naoman.domain.photo.elasticsearch.repository.PhotoEsClientRepository;
 import com.umc.naoman.domain.photo.entity.Photo;
+import com.umc.naoman.domain.photo.entity.SamplePhoto;
 import com.umc.naoman.domain.photo.repository.PhotoRepository;
+import com.umc.naoman.domain.photo.repository.SamplePhotoRepository;
 import com.umc.naoman.domain.shareGroup.entity.ShareGroup;
 import com.umc.naoman.domain.shareGroup.service.ShareGroupService;
 import com.umc.naoman.global.error.BusinessException;
@@ -34,13 +42,15 @@ import static com.umc.naoman.global.error.code.S3ErrorCode.PHOTO_NOT_FOUND_S3;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PhotoServiceImpl implements PhotoService {
-    private final AmazonS3 amazonS3;
-    private final S3Template s3Template;
-    private final PhotoRepository photoRepository;
     private final ShareGroupService shareGroupService;
+    private final FaceDetectionService faceDetectionService;
+    private final PhotoRepository photoRepository;
+    private final SamplePhotoRepository samplePhotoRepository;
     private final PhotoEsClientRepository photoEsClientRepository;
     private final PhotoConverter photoConverter;
-    private final FaceDetectionService faceDetectionService;
+    private final SamplePhotoConverter samplePhotoConverter;
+    private final AmazonS3 amazonS3;
+    private final S3Template s3Template;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
@@ -52,13 +62,8 @@ public class PhotoServiceImpl implements PhotoService {
     public static final String W400_PATH_PREFIX = "w400";
 
     @Override
-    public Photo findPhoto(Long photoId) {
-        return photoRepository.findById(photoId).orElseThrow(() -> new BusinessException(PHOTO_NOT_FOUND));
-    }
-
-    @Override
     @Transactional
-    public List<PhotoResponse.PreSignedUrlInfo> getPreSignedUrlList(PhotoRequest.PreSignedUrlRequest request, Member member) {
+    public List<PreSignedUrlInfo> getPreSignedUrlList(PhotoRequest.PreSignedUrlRequest request, Member member) {
         validateShareGroupAndProfile(request.getShareGroupId(), member);
 
         return request.getPhotoNameList().stream()
@@ -66,10 +71,80 @@ public class PhotoServiceImpl implements PhotoService {
                 .collect(Collectors.toList());
     }
 
+    private PreSignedUrlInfo getPreSignedUrl(String originalFilename) {
+        String fileName = createPath(originalFilename);
+        String photoName = fileName.split("/")[1];
+        String photoUrl = generateFileAccessUrl(fileName);
+
+        URL preSignedUrl = amazonS3.generatePresignedUrl(getGeneratePreSignedUrlRequest(bucketName, fileName));
+        return photoConverter.toPreSignedUrlInfo(preSignedUrl.toString(), photoUrl, photoName);
+    }
+
+    // 원본 사진 전체 경로 생성
+    private String createPath(String fileName) {
+        String fileId = createFileId();
+        return String.format("%s/%s", RAW_PATH_PREFIX, fileId + fileName);
+    }
+
+    // 사진 고유 ID 생성
+    private String createFileId() {
+        return UUID.randomUUID().toString();
+    }
+
+    // 사진 업로드용(PUT) PreSigned URL 생성
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String bucket, String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(getPreSignedUrlExpiration());
+        generatePresignedUrlRequest.addRequestParameter(Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        return generatePresignedUrlRequest;
+    }
+
+    // PreSigned URL 유효 기간 설정
+    private Date getPreSignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 3;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    // 원본 사진의 접근 URL 생성
+    private String generateFileAccessUrl(String fileName) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName);
+    }
+
     @Override
     @Transactional
-    public PhotoResponse.PhotoUploadInfo uploadPhotoList(PhotoRequest.PhotoUploadRequest request, Member member) {
+    public SamplePhotoUploadInfo uploadSamplePhotoList(UploadSamplePhotoRequest request, Member member) {
+        List<SamplePhoto> samplePhotoList = request.getPhotoUrlList().stream()
+                .map(photoUrl -> checkAndSaveSamplePhotoInDB(photoUrl, extractPhotoNameFromUrl(photoUrl), member))
+                .toList();
 
+        List<String> samplePhotoNameList = samplePhotoList.stream()
+                .map(samplePhoto -> samplePhoto.getName())
+                .toList();
+
+        // Elasticsearch에 sample_face_vector를 저장하기 위한 트리거 실행
+        // =================경호님이 작업하실 라인================
+        // dummyFunction(samplePhotoNameList, member.getId());
+
+        return photoConverter.toSamplePhotoUploadInfo(member.getId(), samplePhotoList.size());
+    }
+
+    private SamplePhoto checkAndSaveSamplePhotoInDB(String photoUrl, String photoName, Member member) {
+        if (!amazonS3.doesObjectExist(bucketName, RAW_PATH_PREFIX + "/" + photoName)) {
+            throw new BusinessException(PHOTO_NOT_FOUND_S3);
+        }
+
+        SamplePhoto samplePhoto = samplePhotoConverter.toEntity(photoUrl, photoName, member);
+        return samplePhotoRepository.save(samplePhoto);
+    }
+
+    @Override
+    @Transactional
+    public PhotoUploadInfo uploadPhotoList(PhotoUploadRequest request, Member member) {
         validateShareGroupAndProfile(request.getShareGroupId(), member);
         ShareGroup shareGroup = shareGroupService.findShareGroup(request.getShareGroupId());
 
@@ -86,10 +161,44 @@ public class PhotoServiceImpl implements PhotoService {
                 .map(Photo::getName)
                 .toList();
 
-        // 얼굴 인식 서비스 호출
-        faceDetectionService.detectFaceUploadPhoto(photoNameList, request.getShareGroupId());
 
-        return new PhotoResponse.PhotoUploadInfo(request.getShareGroupId(), photoList.size());
+        List<Long> memberIdList = shareGroupService.findProfileListByShareGroupId(shareGroup.getId()).stream()
+                .filter(profile -> profile.getMember() != null)
+                .map(profile -> profile.getMember().getId())
+                .collect(Collectors.toList());
+        // 얼굴 인식 서비스 호출
+        faceDetectionService.detectFaceUploadPhoto(photoNameList, shareGroup.getId(), memberIdList);
+
+        return photoConverter.toPhotoUploadInfo(shareGroup.getId(), photoList.size());
+    }
+
+    // S3에 객체의 존재 여부 확인 및 DB에 사진을 저장하고 객체를 반환하는 메서드
+    private Photo checkAndSavePhotoInDB(String photoUrl, String photoName, ShareGroup shareGroup) {
+        if (!amazonS3.doesObjectExist(bucketName, RAW_PATH_PREFIX + "/" + photoName)) {
+            throw new BusinessException(PHOTO_NOT_FOUND_S3);
+        }
+
+        Photo photo = photoConverter.toEntity(photoUrl, photoName, shareGroup);
+        return photoRepository.save(photo); // 저장된 Photo 객체 반환
+    }
+
+    // 사진 URL에서 사진 이름을 추출하는 메서드
+    private String extractPhotoNameFromUrl(String photoUrl) {
+        int lastSlashIndex = photoUrl.lastIndexOf('/');
+        return photoUrl.substring(lastSlashIndex + 1);
+    }
+
+    @Override
+    public PhotoDownloadUrlListInfo getPhotoDownloadUrlList(List<Long> photoIdList, Long shareGroupId, Member member) {
+        validateShareGroupAndProfile(shareGroupId, member);
+        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
+
+        if (photoList.size() != photoIdList.size()) {
+            // 요청한 사진이 일부 또는 전부 없을 경우 예외 발생
+            throw new BusinessException(PHOTO_NOT_FOUND);
+        }
+
+        return photoConverter.toPhotoDownloadUrlListInfo(photoList);
     }
 
     @Override
@@ -120,17 +229,11 @@ public class PhotoServiceImpl implements PhotoService {
         return photoList; // 삭제된 사진 목록 반환
     }
 
-    @Override
-    public PhotoResponse.PhotoDownloadUrlListInfo getPhotoDownloadUrlList(List<Long> photoIdList, Long shareGroupId, Member member) {
-        validateShareGroupAndProfile(shareGroupId, member);
-        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
-
-        if (photoList.size() != photoIdList.size()) {
-            // 요청한 사진이 일부 또는 전부 없을 경우 예외 발생
-            throw new BusinessException(PHOTO_NOT_FOUND);
-        }
-
-        return photoConverter.toPhotoDownloadUrlListInfo(photoList);
+    private void deletePhoto(String photoName) {
+        // S3에서 원본 및 변환된 이미지 삭제
+        s3Template.deleteObject(bucketName, RAW_PATH_PREFIX + "/" + photoName);
+        s3Template.deleteObject(bucketName, W200_PATH_PREFIX + "/" + photoConverter.convertExtension(photoName));
+        s3Template.deleteObject(bucketName, W400_PATH_PREFIX + "/" + photoConverter.convertExtension(photoName));
     }
 
     // 해당 공유 그룹이 존재하는지 확인 & 멤버가 해당 공유 그룹에 속해있는지 확인
@@ -139,71 +242,9 @@ public class PhotoServiceImpl implements PhotoService {
         shareGroupService.findProfile(shareGroupId, member.getId());
     }
 
-    private PhotoResponse.PreSignedUrlInfo getPreSignedUrl(String originalFilename) {
-        String fileName = createPath(originalFilename);
-
-        String photoName = fileName.split("/")[1];
-        String photoUrl = generateFileAccessUrl(fileName);
-
-        URL preSignedUrl = amazonS3.generatePresignedUrl(getGeneratePreSignedUrlRequest(bucketName, fileName));
-        return photoConverter.toPreSignedUrlInfo(preSignedUrl.toString(), photoUrl, photoName);
-    }
-
-    // 사진 업로드용(PUT) PreSigned URL 생성
-    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String bucket, String fileName) {
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
-                .withMethod(HttpMethod.PUT)
-                .withExpiration(getPreSignedUrlExpiration());
-        generatePresignedUrlRequest.addRequestParameter(Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
-
-        return generatePresignedUrlRequest;
-    }
-
-    // 원본 사진 전체 경로 생성
-    private String createPath(String fileName) {
-        String fileId = createFileId();
-        return String.format("%s/%s", RAW_PATH_PREFIX, fileId + fileName);
-    }
-
-    // 사진 고유 ID 생성
-    private String createFileId() {
-        return UUID.randomUUID().toString();
-    }
-
-    // 원본 사진의 접근 URL 생성
-    private String generateFileAccessUrl(String fileName) {
-        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName);
-    }
-
-    // PreSigned URL 유효 기간 설정
-    private Date getPreSignedUrlExpiration() {
-        Date expiration = new Date();
-        long expTimeMillis = expiration.getTime();
-        expTimeMillis += 1000 * 60 * 3;
-        expiration.setTime(expTimeMillis);
-        return expiration;
-    }
-
-    // 사진 URL에서 사진 이름을 추출하는 메서드
-    private String extractPhotoNameFromUrl(String photoUrl) {
-        int lastSlashIndex = photoUrl.lastIndexOf('/');
-        return photoUrl.substring(lastSlashIndex + 1);
-    }
-
-    // S3에 객체의 존재 여부 확인 및 DB에 사진을 저장하고 객체를 반환하는 메서드
-    private Photo checkAndSavePhotoInDB(String photoUrl, String photoName, ShareGroup shareGroup) {
-        if (!amazonS3.doesObjectExist(bucketName, RAW_PATH_PREFIX + "/" + photoName)) {
-            throw new BusinessException(PHOTO_NOT_FOUND_S3);
-        }
-
-        Photo photo = photoConverter.toEntity(photoUrl, photoName, shareGroup);
-        return photoRepository.save(photo); // 저장된 Photo 객체 반환
-    }
-
-    private void deletePhoto(String photoName) {
-        // S3에서 원본 및 변환된 이미지 삭제
-        s3Template.deleteObject(bucketName, RAW_PATH_PREFIX + "/" + photoName);
-        s3Template.deleteObject(bucketName, W200_PATH_PREFIX + "/" + photoConverter.convertExtension(photoName));
-        s3Template.deleteObject(bucketName, W400_PATH_PREFIX + "/" + photoConverter.convertExtension(photoName));
+    @Override
+    public Photo findPhoto(Long photoId) {
+        return photoRepository.findById(photoId)
+                .orElseThrow(() -> new BusinessException(PHOTO_NOT_FOUND));
     }
 }

--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ShareGroupServiceImpl implements ShareGroupService {
-
     private final ShareGroupRepository shareGroupRepository;
     private final ProfileRepository profileRepository;
     private final ShareGroupConverter shareGroupConverter;

--- a/src/main/java/com/umc/naoman/global/result/code/PhotoResultCode.java
+++ b/src/main/java/com/umc/naoman/global/result/code/PhotoResultCode.java
@@ -10,11 +10,13 @@ import lombok.RequiredArgsConstructor;
 public enum PhotoResultCode implements ResultCode {
     CREATE_PRESIGNED_URL(200, "SP000", "성공적으로 Presigned URL을 요청하였습니다."),
     UPLOAD_PHOTO(200, "SP000", "성공적으로 이미지를 업로드하였습니다."),
+    UPLOAD_SAMPLE_PHOTO(200, "SP000", "성공적으로 샘플 이미지를 업로드하였습니다."),
     RETRIEVE_PHOTO(200, "SP000", "성공적으로 이미지를 조회하였습니다."),
     DELETE_PHOTO(200, "SP000", "성공적으로 이미지를 삭제하였습니다."),
-    DOWNLOAD_PHOTO(200, "SP000", "성공적으로 이미지를 디운로드하였습니다.")
+    DOWNLOAD_PHOTO(200, "SP000", "성공적으로 이미지를 디운로드하였습니다."),
 
     ;
+
     private final int status;
     private final String code;
     private final String message;

--- a/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
@@ -16,9 +16,9 @@ public class CookieUtils {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")
                 .maxAge(maxAge)
-                //.httpOnly(false)
-                //.secure(true)
-                //.sameSite("None")
+                .httpOnly(false)
+                .secure(true)
+                .sameSite("None")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #87 

## 📝 작업 내용
1. 샘플 이미지 업로드 API 구현
2. `ShareGroupServiceImpl`과 `FaceDetctionServiceImpl`의 순환참조 문제 해결
3. `PhotoController`, `PhotoService`, `PhotoServiceImpl`의 함수 순서를 수정하였다.
4. `PhotoConverter`를 사용하지 않고 `new` 연산자로 dto 객체를 생성하는 코드를 converter를 사용하도록 리팩토링하였다.
5. `PhotoEsInfo`, `PagedPhotoEsInfo`에서 'Es' 키워드를 제거하였다.


## 💭 주의 사항

## 💡 리뷰 포인트
사진 업로드 시, 새로 업로드된 사진에 대해 얼굴 인식을 위해 아래 코드를 호출한다.
`faceDetectionService.detectFaceUploadPhoto(photoNameList, shareGroup.getId(), memberIdList);`
기존에는 `memberIdList` 파라미터를 전달하지 않고, `detectFaceUploadPhoto()` 내부에서 `memberIdList`를 구했다. 이 과정에서 `ShareGroupServiceImpl`을 참조함으로써 순환 참조가 발생하였다. 이를 해결하기 위해, 파라미터로 `memberIdList`를 전달하도록 리팩토링하였다.

리팩토링 과정에서 해당 공유 그룹에 참여한 회원의 프로필에서 `memberId`를 추출할 때, 아직 회원이 참여하지 않은 프로필은 `getMember()`의 값이 null이므로 `filter()` 메소드를 통해 null이 아닌 값만 데이터 가공에 포함되도록 수정하였다.