### PR TITLE
[Fix] 공유그룹 아이디로 photos_es 삭제 시, 공유그룹 아이디를 리스트로 받아오는 것에서 1개만 받아오는 것으로 수정

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/elasticsearch/repository/PhotoEsClientRepository.java
+++ b/src/main/java/com/umc/naoman/domain/photo/elasticsearch/repository/PhotoEsClientRepository.java
@@ -226,10 +226,7 @@ public class PhotoEsClientRepository {
     }
 
     //특정 공유 그룹의 사진 삭제 -> 해당 사진에서 감지된 얼굴벡터도 함께 샥제 return : 삭제된 사진의 rdsId
-    public List<Long> deletePhotoEsByShareGroupIdList(List<Long> shareGroupIdList) {
-        List<FieldValue> fieldValueShareGroupList = shareGroupIdList.stream()
-                .map(FieldValue::of)
-                .toList();
+    public List<Long> deletePhotoEsByShareGroupId(Long shareGroupId) {
         SearchResponse<PhotoEs> response = null;
         List<Long> rdsIdList = new ArrayList<>();
         List<String> photoNameList = new ArrayList<>();
@@ -239,18 +236,18 @@ public class PhotoEsClientRepository {
                             .from(0)
                             .size(5000)
                             .query(q -> q
-                                    .terms(t -> t
+                                    .term(t -> t
                                             .field("shareGroupId")
-                                            .terms(te -> te.value(fieldValueShareGroupList))
+                                            .value(FieldValue.of(shareGroupId))
                                     )
                             ),
                     PhotoEs.class);
             elasticsearchClient.deleteByQuery(d -> d
                     .index("photos_es")
                     .query(q -> q
-                            .terms(t -> t
+                            .term(t -> t
                                     .field("shareGroupId")
-                                    .terms(te -> te.value(fieldValueShareGroupList))
+                                    .value(FieldValue.of(shareGroupId))
                             )
                     )
             );


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #108 

## 📝 작업 내용
공유그룹에 속한 사진 삭제 시, 공유그룹 아이디를 리스트로 받아오는 것에서 1개만 받아오는 것으로 수정. 
## 💭 주의 사항

## 💡 리뷰 포인트