### PR TITLE
[FEAT] 회원 탈퇴시 필요한 사진 삭제 함수 구현

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -26,6 +26,10 @@ public interface PhotoService {
 
     List<Photo> deletePhotoList(PhotoRequest.PhotoDeletedRequest request, Member member);
 
+    //  사진 목록에서 특정 회원의 사진을 삭제하는 함수
+    void deletePhotoEsByFaceTag(Long memberId);
+
     Photo findPhoto(Long photoId);
+
     boolean hasSamplePhoto(Member member);
 }

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -26,7 +26,10 @@ public interface PhotoService {
 
     List<Photo> deletePhotoList(PhotoRequest.PhotoDeletedRequest request, Member member);
 
-    //  사진 목록에서 특정 회원의 사진을 삭제하는 함수
+    // 특정 공유 그룹의 모든 사진을 삭제하는 함수
+    void deletePhotoEsByShareGroupIdList(List<Long> shareGroupIdList);
+
+    // 사진 목록에서 특정 회원의 사진을 삭제하는 함수
     void deletePhotoEsByFaceTag(Long memberId);
 
     Photo findPhoto(Long photoId);

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -27,10 +27,10 @@ public interface PhotoService {
     List<Photo> deletePhotoList(PhotoRequest.PhotoDeletedRequest request, Member member);
 
     // 사진 목록에서 특정 회원의 사진을 삭제하는 함수
-    void deletePhotoByFaceTag(Long memberId);
+    void deletePhotoListByFaceTag(Long memberId);
 
     // 특정 공유 그룹의 모든 사진을 삭제하는 함수
-    void deletePhotoByShareGroupId(Long shareGroupIdList);
+    void deletePhotoListByShareGroupId(Long shareGroupId);
 
     Photo findPhoto(Long photoId);
 

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -26,11 +26,11 @@ public interface PhotoService {
 
     List<Photo> deletePhotoList(PhotoRequest.PhotoDeletedRequest request, Member member);
 
-    // 특정 공유 그룹의 모든 사진을 삭제하는 함수
-    void deletePhotoEsByShareGroupIdList(List<Long> shareGroupIdList);
-
     // 사진 목록에서 특정 회원의 사진을 삭제하는 함수
-    void deletePhotoEsByFaceTag(Long memberId);
+    void deletePhotoByFaceTag(Long memberId);
+
+    // 특정 공유 그룹의 모든 사진을 삭제하는 함수
+    void deletePhotoByShareGroupId(Long shareGroupIdList);
 
     Photo findPhoto(Long photoId);
 

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -283,16 +283,21 @@ public class PhotoServiceImpl implements PhotoService {
         photoRepository.deleteAllByPhotoIdList(photoIdList);
         photoEsClientRepository.deletePhotoEsByRdsId(photoIdList, request.getShareGroupId());
 
-        return photoList; // 삭제된 사진 목록 반환
+        // 삭제된 사진 목록 반환
+        return photoList;
     }
 
     @Override
     @Transactional
-    public void deletePhotoEsByFaceTag(Long memberId) {
+    public void deletePhotoByFaceTag(Long memberId) {
+        // Elasticsearch 사진 데이터 삭제
         List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByFaceTag(memberId);
         List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
+
+        // RDBMS 사진 데이터 삭제
         photoRepository.deleteAllByPhotoIdList(photoIdList);
 
+        // S3 버킷 사진 데이터 삭제
         for (Photo photo : photoList) {
             deletePhoto(photo.getName());
         }
@@ -300,11 +305,15 @@ public class PhotoServiceImpl implements PhotoService {
 
     @Override
     @Transactional
-    public void deletePhotoEsByShareGroupIdList(List<Long> shareGroupIdList) {
-        List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByShareGroupIdList(shareGroupIdList);
+    public void deletePhotoByShareGroupId(Long shareGroupId) {
+        // Elasticsearch 사진 데이터 삭제
+        List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByShareGroupId(shareGroupId);
         List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
+
+        // RDBMS 사진 데이터 삭제
         photoRepository.deleteAllByPhotoIdList(photoIdList);
 
+        // S3 버킷 사진 데이터 삭제
         for (Photo photo : photoList) {
             deletePhoto(photo.getName());
         }

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -270,7 +270,7 @@ public class PhotoServiceImpl implements PhotoService {
             throw new BusinessException(PHOTO_NOT_FOUND);
         }
 
-        // 각 사진에 대해 S3에서 객체 삭제 및 데이터베이스에서 삭제
+        // 각 사진에 대해 S3에서 객체 삭제
         for (Photo photo : photoList) {
             deletePhoto(photo.getName());
         }
@@ -285,6 +285,20 @@ public class PhotoServiceImpl implements PhotoService {
 
         return photoList; // 삭제된 사진 목록 반환
     }
+
+    @Override
+    @Transactional
+    public void deletePhotoEsByFaceTag(Long memberId) {
+        List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByFaceTag(memberId);
+        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
+        photoRepository.deleteAllByPhotoIdList(photoIdList);
+
+        for (Photo photo : photoList) {
+            deletePhoto(photo.getName());
+        }
+    }
+
+
 
     private void deletePhoto(String photoName) {
         // S3에서 원본 및 변환된 이미지 삭제

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -289,34 +289,36 @@ public class PhotoServiceImpl implements PhotoService {
 
     @Override
     @Transactional
-    public void deletePhotoByFaceTag(Long memberId) {
+    public void deletePhotoListByFaceTag(Long memberId) {
         // Elasticsearch 사진 데이터 삭제
         List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByFaceTag(memberId);
 
-        // RDBMS 사진 데이터 삭제
         List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
-        photoRepository.deleteAllByPhotoIdList(photoIdList);
 
         // S3 버킷 사진 데이터 삭제
         for (Photo photo : photoList) {
             deletePhoto(photo.getName());
         }
+
+        // RDBMS 사진 데이터 삭제
+        photoRepository.deleteAllByPhotoIdList(photoIdList);
     }
 
     @Override
     @Transactional
-    public void deletePhotoByShareGroupId(Long shareGroupId) {
+    public void deletePhotoListByShareGroupId(Long shareGroupId) {
         // Elasticsearch 사진 데이터 삭제
         List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByShareGroupId(shareGroupId);
 
-        // RDBMS 사진 데이터 삭제
         List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
-        photoRepository.deleteAllByPhotoIdList(photoIdList);
 
         // S3 버킷 사진 데이터 삭제
         for (Photo photo : photoList) {
             deletePhoto(photo.getName());
         }
+
+        // RDBMS 사진 데이터 삭제
+        photoRepository.deleteAllByPhotoIdList(photoIdList);
     }
 
     private void deletePhoto(String photoName) {

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -298,7 +298,17 @@ public class PhotoServiceImpl implements PhotoService {
         }
     }
 
+    @Override
+    @Transactional
+    public void deletePhotoEsByShareGroupIdList(List<Long> shareGroupIdList) {
+        List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByShareGroupIdList(shareGroupIdList);
+        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
+        photoRepository.deleteAllByPhotoIdList(photoIdList);
 
+        for (Photo photo : photoList) {
+            deletePhoto(photo.getName());
+        }
+    }
 
     private void deletePhoto(String photoName) {
         // S3에서 원본 및 변환된 이미지 삭제

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -292,9 +292,9 @@ public class PhotoServiceImpl implements PhotoService {
     public void deletePhotoByFaceTag(Long memberId) {
         // Elasticsearch 사진 데이터 삭제
         List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByFaceTag(memberId);
-        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
 
         // RDBMS 사진 데이터 삭제
+        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
         photoRepository.deleteAllByPhotoIdList(photoIdList);
 
         // S3 버킷 사진 데이터 삭제
@@ -308,9 +308,9 @@ public class PhotoServiceImpl implements PhotoService {
     public void deletePhotoByShareGroupId(Long shareGroupId) {
         // Elasticsearch 사진 데이터 삭제
         List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByShareGroupId(shareGroupId);
-        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
 
         // RDBMS 사진 데이터 삭제
+        List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
         photoRepository.deleteAllByPhotoIdList(photoIdList);
 
         // S3 버킷 사진 데이터 삭제


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#105 

## 📝 작업 내용
회원 탈퇴시 필요한 사진 삭제 함수를 구현하엿습니다.
- 해당 회원이 나온 사진 전체 삭제 함수
- 특정 공유 그룹의 사진 전체 삭제 함수

## 💭 주의 사항

## 💡 리뷰 포인트