### PR TITLE
[FEAT] 회원의 샘플 사진을 모두 삭제하는 함수 구현

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/repository/SamplePhotoRepository.java
+++ b/src/main/java/com/umc/naoman/domain/photo/repository/SamplePhotoRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SamplePhotoRepository extends JpaRepository<SamplePhoto, Long> {
     boolean existsByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -32,6 +32,8 @@ public interface PhotoService {
     // 특정 공유 그룹의 모든 사진을 삭제하는 함수
     void deletePhotoListByShareGroupId(Long shareGroupId);
 
+    void deleteSamplePhotoList(Member member);
+
     Photo findPhoto(Long photoId);
 
     boolean hasSamplePhoto(Member member);

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -18,6 +18,7 @@ import com.umc.naoman.domain.photo.dto.PhotoResponse.PreSignedUrlInfo;
 import com.umc.naoman.domain.photo.dto.PhotoResponse.SamplePhotoUploadInfo;
 import com.umc.naoman.domain.photo.elasticsearch.document.PhotoEs;
 import com.umc.naoman.domain.photo.elasticsearch.repository.PhotoEsClientRepository;
+import com.umc.naoman.domain.photo.elasticsearch.repository.SampleFaceVectorClientRepository;
 import com.umc.naoman.domain.photo.entity.Photo;
 import com.umc.naoman.domain.photo.entity.SamplePhoto;
 import com.umc.naoman.domain.photo.repository.PhotoRepository;
@@ -52,6 +53,7 @@ public class PhotoServiceImpl implements PhotoService {
     private final PhotoRepository photoRepository;
     private final SamplePhotoRepository samplePhotoRepository;
     private final PhotoEsClientRepository photoEsClientRepository;
+    private final SampleFaceVectorClientRepository sampleFaceVectorClientRepository;
     private final PhotoConverter photoConverter;
     private final SamplePhotoConverter samplePhotoConverter;
     private final AmazonS3 amazonS3;
@@ -328,6 +330,16 @@ public class PhotoServiceImpl implements PhotoService {
 
         // RDBMS 사진 데이터 삭제
         photoRepository.deleteAllByPhotoIdList(photoIdList);
+    }
+
+    @Override
+    @Transactional
+    public void deleteSamplePhotoList(Member member) {
+        // 엔티티 삭제 (hard delete)
+        samplePhotoRepository.deleteByMemberId(member.getId());
+
+        // ElasticSearch 데이터 삭제
+        sampleFaceVectorClientRepository.deleteSampleFaceVectorByMemberId(member.getId());
     }
 
     private void deletePhoto(String photoName) {


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #116 

## 📝 작업 내용
`Member` 객체를 파라미터로 받아, 해당 회원이 업로드한 샘플 사진을 나타내는 `SamplePhoto` 객체를 **hard delete**하고,
사진에서 추출한 `sample face vector`를 ElasticSearch의 `sample_face_vectors` 인덱스에서도 삭제하는 함수를 구현하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트