### PR TITLE
[FIX] photos_es 페이지 조회의 결과가 무조건 isLast값이 true인 버그 수정

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/elasticsearch/repository/PhotoEsClientRepository.java
+++ b/src/main/java/com/umc/naoman/domain/photo/elasticsearch/repository/PhotoEsClientRepository.java
@@ -89,7 +89,7 @@ public class PhotoEsClientRepository {
         } catch (IOException e) {
             throw new BusinessException(ElasticsearchErrorCode.ELASTICSEARCH_IOEXCEPTION, e);
         }
-        return toPagePhotoEs(response.hits().hits(), pageable);
+        return toPagePhotoEs(response.hits().hits(), pageable, response.hits().total().value());
     }
 
     //특정 공유 그룹의 얼굴이 태그된 사진 검색
@@ -127,7 +127,7 @@ public class PhotoEsClientRepository {
             throw new BusinessException(ElasticsearchErrorCode.ELASTICSEARCH_IOEXCEPTION, e);
         }
 
-        return toPagePhotoEs(response.hits().hits(), pageable);
+        return toPagePhotoEs(response.hits().hits(), pageable,response.hits().total().value());
     }
 
     //특정 공유 그룹의 얼굴이 태그되지 않은 사진 검색
@@ -164,7 +164,7 @@ public class PhotoEsClientRepository {
             throw new BusinessException(ElasticsearchErrorCode.ELASTICSEARCH_IOEXCEPTION, e);
         }
 
-        return toPagePhotoEs(response.hits().hits(), pageable);
+        return toPagePhotoEs(response.hits().hits(), pageable,response.hits().total().value());
     }
 
     // rdsId로 ES에서 사진 삭제
@@ -304,9 +304,11 @@ public class PhotoEsClientRepository {
         return localDateTime.format(dateTimeFormatter);
     }
 
-    private Page<PhotoEs> toPagePhotoEs(List<Hit<PhotoEs>> hits, Pageable pageable) {
-        List<PhotoEs> photoEsList = hits.stream().map(Hit::source).collect(Collectors.toList());
-        return new PageImpl<>(photoEsList, pageable, hits.size());
+    private Page<PhotoEs> toPagePhotoEs(List<Hit<PhotoEs>> hits, Pageable pageable, long total) {
+        List<PhotoEs> photoEsList = hits.stream()
+                                        .map(Hit::source)
+                                        .collect(Collectors.toList());
+        return new PageImpl<>(photoEsList, pageable, total);
     }
 
     private int getFrom(Pageable pageable) {


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #119 

## 📝 작업 내용
전체 문서 개수를 잘못 가져옴
-> hits->hits의 배열 크기에서 hits->total->value로 수정

## 💭 주의 사항

## 💡 리뷰 포인트