### PR TITLE
[FEAT] 성능 이슈가 의심되는 특정 API에 대한 수행 시간 로깅 추가

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -44,6 +45,7 @@ import static com.umc.naoman.global.result.code.PhotoResultCode.*;
 
 @RestController
 @RequestMapping("/photos")
+@Slf4j
 @RequiredArgsConstructor
 @Tag(name = "03. 사진 관련 API", description = "사진 업로드, 조회, 삭제, 다운로드를 처리하는 API입니다.")
 public class PhotoController {
@@ -56,7 +58,10 @@ public class PhotoController {
     @Operation(summary = "Presigned URL 요청 API", description = "Presigned URL을 요청하는 API입니다.")
     public ResultResponse<PreSignedUrlListInfo> getPreSignedUrlList(@Valid @RequestBody PreSignedUrlRequest request,
                                                                     @LoginMember Member member) {
+        long startTime = System.currentTimeMillis();
         List<PreSignedUrlInfo> preSignedUrlList = photoService.getPreSignedUrlList(request, member);
+        long finishTime = System.currentTimeMillis();
+        log.info("PhotoServiceImpl.getPreSignedUrlList() 수행 시간: {} ms", finishTime - startTime);
         return ResultResponse.of(CREATE_PRESIGNED_URL, photoConverter.toPreSignedUrlListInfo(preSignedUrlList));
     }
 
@@ -71,7 +76,10 @@ public class PhotoController {
     @Operation(summary = "사진 업로드 API", description = "Presigned URL을 통해 업로드한 사진을 데이터베이스에 저장하는 API입니다.")
     public ResultResponse<PhotoUploadInfo> uploadPhotoList(@Valid @RequestBody PhotoUploadRequest request,
                                                            @LoginMember Member member) {
+        long startTime = System.currentTimeMillis();
         PhotoUploadInfo photoUploadInfo = photoService.uploadPhotoList(request, member);
+        long finishTime = System.currentTimeMillis();
+        log.info("PhotoServiceImpl.uploadPhotoList() 수행 시간: {} ms", finishTime - startTime);
         return ResultResponse.of(UPLOAD_PHOTO, photoUploadInfo);
     }
 
@@ -131,7 +139,10 @@ public class PhotoController {
     public ResultResponse<PhotoDownloadUrlListInfo> getPhotoDownloadUrlList(@RequestParam List<Long> photoIdList,
                                                                             @RequestParam Long shareGroupId,
                                                                             @LoginMember Member member) {
+        long startTime = System.currentTimeMillis();
         PhotoDownloadUrlListInfo photoDownloadUrlList = photoService.getPhotoDownloadUrlList(photoIdList, shareGroupId, member);
+        long finishTime = System.currentTimeMillis();
+        log.info("PhotoServiceImpl.getPhotoDownloadUrlList() 수행 시간: {} ms", finishTime - startTime);
         return ResultResponse.of(DOWNLOAD_PHOTO, photoDownloadUrlList);
     }
 
@@ -144,7 +155,10 @@ public class PhotoController {
     public ResultResponse<PhotoDownloadUrlListInfo> getPhotoDownloadUrlListByProfile(@RequestParam Long shareGroupId,
                                                                                      @RequestParam Long profileId,
                                                                                      @LoginMember Member member) {
+        long startTime = System.currentTimeMillis();
         PhotoResponse.PhotoDownloadUrlListInfo photoDownloadUrlList = photoService.getPhotoDownloadUrlListByProfile(shareGroupId, profileId, member);
+        long finishTime = System.currentTimeMillis();
+        log.info("PhotoServiceImpl.getPhotoDownloadUrlListByProfile() 수행 시간: {} ms", finishTime - startTime);
         return ResultResponse.of(DOWNLOAD_PHOTO, photoDownloadUrlList);
     }
 


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #124 

## 📝 작업 내용
- 사진 업로드 API
- 특정 회원에 대한 앨범의 모든 사진 다운로드 API
- `presigned URL` 요청 API

3개의 API에 대하여 각 서비스단 함수의 수행 시간과, 별도로 Amazon S3에 사진 객체가 존재하는지 확인하는 `doesObjectExists()` 함수의 수행 시간 측정 로깅을 추가하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트