### PR TITLE
[FIX] 탈퇴 시 안건 후보로 등록된 사진 삭제 불가 이슈 해결

### DIFF
--- a/src/main/java/com/umc/naoman/domain/agenda/dto/AgendaResponse.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/dto/AgendaResponse.java
@@ -39,7 +39,7 @@ public abstract class AgendaResponse {
         private List<AgendaDetailInfo> agendaDetailInfoList;
         private int totalPages;
         private long totalElements; // 해당 조건에 부합하는 요소의 총 개수
-        private boolean isFirst; // 첫 페이지 여부
-        private boolean isLast; // 마지막 페이지 여부
+        private Boolean isFirst; // 첫 페이지 여부
+        private Boolean isLast; // 마지막 페이지 여부
     }
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/entity/AgendaPhoto.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/entity/AgendaPhoto.java
@@ -40,4 +40,8 @@ public class AgendaPhoto extends BaseTimeEntity {
         }
         super.delete();
     }
+
+    public void nullifyPhoto() {
+        this.photo = null;
+    }
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/repository/AgendaPhotoRepository.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/repository/AgendaPhotoRepository.java
@@ -2,6 +2,7 @@ package com.umc.naoman.domain.agenda.repository;
 
 import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +11,5 @@ import java.util.List;
 public interface AgendaPhotoRepository extends JpaRepository<AgendaPhoto, Long> {
     List<AgendaPhoto> findByAgendaId(Long agendaId);
     List<AgendaPhoto> findByPhotoId(Long photoId);
+    List<AgendaPhoto> findByPhotoIdIn(List<Long> photoIdList);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoService.java
@@ -11,4 +11,5 @@ public interface AgendaPhotoService {
     AgendaPhoto findAgendaPhoto(Long agendaPhotoId);
     List<AgendaPhoto> findAgendaPhotoList(Long agendaId);
     List<AgendaPhoto> findAgendaPhotoListByPhotoId(Long photoId);
+    void nullifyPhotoInAgendaPhotoList(List<Long> photoIdList);
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaPhotoServiceImpl.java
@@ -5,7 +5,7 @@ import com.umc.naoman.domain.agenda.entity.Agenda;
 import com.umc.naoman.domain.agenda.entity.AgendaPhoto;
 import com.umc.naoman.domain.agenda.repository.AgendaPhotoRepository;
 import com.umc.naoman.domain.photo.entity.Photo;
-import com.umc.naoman.domain.photo.service.PhotoService;
+import com.umc.naoman.domain.photo.service.PhotoQueryService;
 import com.umc.naoman.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,14 +19,14 @@ import static com.umc.naoman.global.error.code.AgendaErrorCode.AGENDA_PHOTO_NOT_
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AgendaPhotoServiceImpl implements AgendaPhotoService {
-    private final PhotoService photoService;
+    private final PhotoQueryService photoQueryService;
     private final AgendaPhotoRepository agendaPhotoRepository;
 
     @Override
     @Transactional
     public void saveAgendaPhotoList(Agenda agenda, List<Long> photos) {
         for (Long photoId : photos) {
-            Photo photo = photoService.findPhoto(photoId);
+            Photo photo = photoQueryService.findPhoto(photoId);
             agendaPhotoRepository.save(AgendaPhotoConverter.toEntity(agenda, photo));
         }
     }
@@ -45,5 +45,13 @@ public class AgendaPhotoServiceImpl implements AgendaPhotoService {
     @Override
     public List<AgendaPhoto> findAgendaPhotoListByPhotoId(Long photoId) {
         return agendaPhotoRepository.findByPhotoId(photoId);
+    }
+
+    @Override
+    @Transactional
+    public void nullifyPhotoInAgendaPhotoList(List<Long> photoIdList) {
+        List<AgendaPhoto> agendaPhotoList = agendaPhotoRepository.findByPhotoIdIn(photoIdList);
+        agendaPhotoList
+                .forEach(AgendaPhoto::nullifyPhoto);
     }
 }

--- a/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/agenda/service/AgendaServiceImpl.java
@@ -28,9 +28,9 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AgendaServiceImpl implements AgendaService {
-    private final AgendaRepository agendaRepository;
     private final ShareGroupService shareGroupService;
     private final AgendaPhotoService agendaPhotoService;
+    private final AgendaRepository agendaRepository;
     private final AgendaConverter agendaConverter;
 
     @Override

--- a/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/member/service/MemberServiceImpl.java
@@ -13,6 +13,7 @@ import com.umc.naoman.domain.member.entity.Member;
 import com.umc.naoman.domain.member.entity.SocialType;
 import com.umc.naoman.domain.member.repository.MemberRepository;
 import com.umc.naoman.domain.member.service.redis.RefreshTokenService;
+import com.umc.naoman.domain.photo.service.PhotoQueryService;
 import com.umc.naoman.domain.photo.service.PhotoService;
 import com.umc.naoman.domain.shareGroup.entity.Profile;
 import com.umc.naoman.domain.shareGroup.entity.Role;
@@ -35,6 +36,7 @@ import static com.umc.naoman.global.error.code.MemberErrorCode.*;
 public class MemberServiceImpl implements MemberService {
     private final RefreshTokenService refreshTokenService;
     private final PhotoService photoService;
+    private final PhotoQueryService photoQueryService;
     private final MemberRepository memberRepository;
     private final MemberConverter memberConverter;
     private final ShareGroupService shareGroupService;
@@ -97,7 +99,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public HasSamplePhoto hasSamplePhoto(Member member) {
-        boolean hasSamplePhoto = photoService.hasSamplePhoto(member);
+        boolean hasSamplePhoto = photoQueryService.hasSamplePhoto(member);
         return memberConverter.toHasSamplePhoto(hasSamplePhoto);
     }
 

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoQueryService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoQueryService.java
@@ -1,0 +1,9 @@
+package com.umc.naoman.domain.photo.service;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.photo.entity.Photo;
+
+public interface PhotoQueryService {
+    Photo findPhoto(Long photoId);
+    boolean hasSamplePhoto(Member member);
+}

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoQueryServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoQueryServiceImpl.java
@@ -1,0 +1,31 @@
+package com.umc.naoman.domain.photo.service;
+
+import com.umc.naoman.domain.member.entity.Member;
+import com.umc.naoman.domain.photo.entity.Photo;
+import com.umc.naoman.domain.photo.repository.PhotoRepository;
+import com.umc.naoman.domain.photo.repository.SamplePhotoRepository;
+import com.umc.naoman.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.umc.naoman.global.error.code.S3ErrorCode.PHOTO_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PhotoQueryServiceImpl implements PhotoQueryService {
+    private final PhotoRepository photoRepository;
+    private final SamplePhotoRepository samplePhotoRepository;
+
+    @Override
+    public Photo findPhoto(Long photoId) {
+        return photoRepository.findById(photoId)
+                .orElseThrow(() -> new BusinessException(PHOTO_NOT_FOUND));
+    }
+
+    @Override
+    public boolean hasSamplePhoto(Member member) {
+        return samplePhotoRepository.existsByMemberId(member.getId());
+    }
+}

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -34,7 +34,7 @@ public interface PhotoService {
 
     void deleteSamplePhotoList(Member member);
 
-    Photo findPhoto(Long photoId);
+//    Photo findPhoto(Long photoId);
 
-    boolean hasSamplePhoto(Member member);
+//    boolean hasSamplePhoto(Member member);
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #126 

## 📝 작업 내용
1. 회원 탈퇴 시 해당 회원과 관련된 사진을 삭제하기 전, 해당 사진을 참조하는 `AgendaPhoto` 객체의 `photo` 필드를 null로 바꾸는 로직을 추가하였습니다.
2. `AgendaResponse`의 `PagedAgendaDetailInfo` 클래스에서 `isFirst`, `isLast` 필드의 타입을 `Boolean` 래퍼 클래스로 변경하였습니다.
3. CQRS 패턴에 따라 `PhotoService`에서 `PhotoQueryService`를 분화하여 순환 참조를 방지하였습니다.
## 💭 주의 사항

## 💡 리뷰 포인트