### PR TITLE
[FIX] 회원 탈퇴 시 누락된 함수 호출 로직 추가

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -330,9 +330,10 @@ public class PhotoServiceImpl implements PhotoService {
     public void deletePhotoListByFaceTag(Long memberId) {
         // Elasticsearch 사진 데이터 삭제
         List<Long> photoIdList = photoEsClientRepository.deletePhotoEsByFaceTag(memberId);
+        // 삭제하려는 사진들 중 안건 후보로 등록된 것들에 대하여, 해당 사진들의 참조를 삭제
+        agendaPhotoService.nullifyPhotoInAgendaPhotoList(photoIdList);
 
         List<Photo> photoList = photoRepository.findByIdIn(photoIdList);
-
         // S3 버킷 사진 데이터 삭제
         for (Photo photo : photoList) {
             deletePhoto(photo.getName());


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #127 

## 📝 작업 내용
회원이 공유그룹의 `Creator`가 아닌 경우 호출하는 사진 삭제 함수 `deletePhotoListByFaceTag(Long memberId)` 내부에 누락된 함수 호출 로직 추가하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트