### PR TITLE
[FEAT] 공유 그룹의 대표 이미지를 초기화하는 로직 추가

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/elasticsearch/service/PhotoEsServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/elasticsearch/service/PhotoEsServiceImpl.java
@@ -29,7 +29,7 @@ public class PhotoEsServiceImpl implements PhotoEsService {
     }
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public Page<PhotoEs> getAllPhotoEsListByShareGroupId(Long shareGroupId, Member member, Pageable pageable) {
         validateShareGroupAndProfile(shareGroupId, member);
         Page<PhotoEs> photoEsList = photoEsClientRepository.findPhotoEsByShareGroupId(shareGroupId, pageable);

--- a/src/main/java/com/umc/naoman/domain/shareGroup/entity/ShareGroup.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/entity/ShareGroup.java
@@ -53,4 +53,8 @@ public class ShareGroup extends BaseTimeEntity {
         }
         super.delete();
     }
+
+    public void updateImage(String image) {
+        this.image = image;
+    }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
Closes #129 

## 📝 작업 내용
사진이 업로드된 공유 그룹에 대하여, 전체 사진 조회 시 공유 그룹의 대표 이미지를 초기화하는 로직을 추가하였습니다.
이때 선정되는 대표 이미지는, `사진에 인식된 회원 수`가 `해당 공유 그룹의 참여자 수 / 2`보다 크거나 같은 사진들 중 `findFirst()`로 선정하였습니다.

## 💭 주의 사항

## 💡 리뷰 포인트