### PR TITLE
[FEAT] 특정 공유그룹 사진 전체 다운로드 API 구현

### DIFF
--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -157,7 +157,6 @@ public class PhotoController {
         return ResultResponse.of(DOWNLOAD_PHOTO, photoDownloadUrlList);
     }
 
-
     @GetMapping("/download/album")
     @Operation(summary = "특정 앨범 사진 전체 다운로드 API", description = "선택한 앨범에 속한 사진을 다운로드할 주소를 받는 API입니다. 해당 공유그룹에 속해있는 회원만 다운로드 요청할 수 있습니다.")
     @Parameters(value = {

--- a/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/umc/naoman/domain/photo/controller/PhotoController.java
@@ -147,6 +147,18 @@ public class PhotoController {
     }
 
     @GetMapping("/download/all")
+    @Operation(summary = "특정 공유그룹의 사진 전체 다운로드 API", description = "사용자가 속한 공유그룹의 전체 사진을 다운로드할 주소를 받는 API입니다. 해당 공유그룹에 속해있는 회원만 다운로드 요청할 수 있습니다.")
+    @Parameters(value = {
+            @Parameter(name = "shareGroupId", description = "다운로드할 사진이 있는 공유그룹의 아이디를 입력해주세요."),
+    })
+    public ResultResponse<PhotoDownloadUrlListInfo> getPhotoDownloadUrlListByShareGroup(@RequestParam Long shareGroupId,
+                                                                                        @LoginMember Member member) {
+        PhotoResponse.PhotoDownloadUrlListInfo photoDownloadUrlList = photoService.getPhotoDownloadUrlListByShareGroup(shareGroupId, member);
+        return ResultResponse.of(DOWNLOAD_PHOTO, photoDownloadUrlList);
+    }
+
+
+    @GetMapping("/download/album")
     @Operation(summary = "특정 앨범 사진 전체 다운로드 API", description = "선택한 앨범에 속한 사진을 다운로드할 주소를 받는 API입니다. 해당 공유그룹에 속해있는 회원만 다운로드 요청할 수 있습니다.")
     @Parameters(value = {
             @Parameter(name = "shareGroupId", description = "다운로드할 사진이 있는 공유그룹의 아이디를 입력해주세요."),

--- a/src/main/java/com/umc/naoman/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/umc/naoman/domain/photo/repository/PhotoRepository.java
@@ -11,9 +11,11 @@ import java.util.List;
 
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
-    List<Photo> findByIdInAndShareGroupId(List<Long> photoIdList, Long shareGroupId);
-
     List<Photo> findByIdIn(List<Long> photoIdList);
+
+    List<Photo> findByShareGroupId(Long ShareGroupId);
+
+    List<Photo> findByIdInAndShareGroupId(List<Long> photoIdList, Long shareGroupId);
 
     @Modifying
     @Query("DELETE FROM Photo p WHERE p.id IN :photoIdList")

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoService.java
@@ -20,6 +20,8 @@ public interface PhotoService {
 
     PhotoDownloadUrlListInfo getPhotoDownloadUrlList(List<Long> photoIdList, Long shareGroupId, Member member);
 
+    PhotoDownloadUrlListInfo getPhotoDownloadUrlListByShareGroup(Long shareGroupId, Member member);
+
     PhotoDownloadUrlListInfo getPhotoDownloadUrlListByProfile(Long shareGroupId, Long profileId, Member member);
 
     PhotoDownloadUrlListInfo getEtcPhotoDownloadUrlList(Long shareGroupId, Member member);

--- a/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/photo/service/PhotoServiceImpl.java
@@ -241,6 +241,20 @@ public class PhotoServiceImpl implements PhotoService {
     }
 
     @Override
+    public PhotoDownloadUrlListInfo getPhotoDownloadUrlListByShareGroup(Long shareGroupId, Member member) {
+        validateShareGroupAndProfile(shareGroupId, member);
+        List<Photo> photoList = photoRepository.findByShareGroupId(shareGroupId);
+
+        List<String> photoUrlList = photoList.stream()
+                .map(Photo::getUrl)
+                .collect(Collectors.toList());
+
+        photoEsClientRepository.addDownloadTag(photoUrlList, member.getId());
+
+        return photoConverter.toPhotoDownloadUrlListInfo(photoUrlList);
+    }
+
+    @Override
     public PhotoDownloadUrlListInfo getPhotoDownloadUrlListByProfile(Long shareGroupId, Long profileId, Member member) {
         validateShareGroupAndProfile(shareGroupId, member);
         Long memberId = shareGroupService.findProfile(profileId).getMember().getId();


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#132 

## 📝 작업 내용
특정 공유 그룹의 사진을 전체 다운로드하는 API입니다.

## 💭 주의 사항

## 💡 리뷰 포인트

- 해당 API 추가로 인해 특정 앨범의 사진을 전체 다운로드 하는 API의 매핑명을 수정하였습니다.
`download/all` → `download/album`