### PR TITLE
[FIX] 이미 존재하는 프로필에 참여 못하게 하는 로직

### DIFF
--- a/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/com/umc/naoman/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -85,6 +85,11 @@ public class ShareGroupServiceImpl implements ShareGroupService {
             throw new BusinessException(ShareGroupErrorCode.INVALID_PROFILE_FOR_GROUP);
         }
 
+        //공유그룹에 해당 profile로 참여한 회원이 이미 있으면
+        if (profile.getMember() != null) {
+            throw new BusinessException(ShareGroupErrorCode.MEMBER_ALREADY_EXIST);
+        }
+
         //해당 멤버(본인)을 선택한 profile에 세팅, 저장
         profile.setInfo(member);
         profileRepository.save(profile);

--- a/src/main/java/com/umc/naoman/global/error/code/ShareGroupErrorCode.java
+++ b/src/main/java/com/umc/naoman/global/error/code/ShareGroupErrorCode.java
@@ -18,7 +18,8 @@ public enum ShareGroupErrorCode implements ErrorCode {
     INVALID_PROFILE_FOR_GROUP(400, "EG007", "해당 프로필은 이 공유 그룹에 속하지 않습니다."),
 
     UNAUTHORIZED_DELETE(403, "EG008", "공유 그룹을 삭제할 권한이 없습니다."),
-    ALREADY_JOINED(400, "EG009", "이미 해당 공유 그룹에 참여하였습니다.");
+    ALREADY_JOINED(400, "EG009", "이미 해당 공유 그룹에 참여하였습니다."),
+    MEMBER_ALREADY_EXIST(400, "EG010", "이미 해당 프로필로 공유 그룹에 참여한 멤버가 존재합니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
+++ b/src/main/java/com/umc/naoman/global/security/util/CookieUtils.java
@@ -12,15 +12,16 @@ import java.io.Serializable;
 import java.util.Base64;
 
 public class CookieUtils {
-    private static final String COOKIE_DOMAIN = ".naoman.site";
+//    private static final String COOKIE_DOMAIN = ".naoman.site";
+    private static final String COOKIE_DOMAIN = "localhost";
     public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")
                 .domain(COOKIE_DOMAIN)
                 .maxAge(maxAge)
                 .httpOnly(false)
-                .secure(true)
-                .sameSite("None")
+//                .secure(true)
+//                .sameSite("None")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ❗️ 이슈 번호
#131 

## 📝 작업 내용
공유 그룹 참여 시, 이미 참여된 프로필로도 참여가 가능하여 해당 프로필에 회원이 덮어씌워지는 문제를 참여 전 검증 로직을 통해 해결했습니다.

## 💭 주의 사항

## 💡 리뷰 포인트